### PR TITLE
[TASK] Introduce unit testing based on `PHPUnit`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - 'main'
   pull_request:
-  
+
 jobs:
   code-quality:
     name: "code quality"
@@ -33,3 +33,22 @@ jobs:
           
       - name: "Run PHPStan"
         run: "Build/Scripts/runTests.sh -b docker -p ${{ matrix.php-version }} -s phpstan"
+
+  unit:
+    name: "unit-tests"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
+        suite: [ 'unit', 'unitRandom' ]
+    steps:
+
+      - name: "Checkout"
+        uses: actions/checkout@v4
+
+      - name: "Install dependencies"
+        run: "Build/Scripts/runTests.sh -b docker -p ${{ matrix.php-version }} -s composerInstall"
+
+      - name: "Test ${{ matrix.suite }} with ${{ matrix.php-version }}"
+        run: "Build/Scripts/runTests.sh -b docker -p ${{ matrix.php-version }} -s ${{ matrix.suite }}"

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -312,6 +312,18 @@ case ${TEST_SUITE} in
         ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name phpstan-baseline-${SUFFIX} -e COMPOSER_CACHE_DIR=.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} "${COMMAND[@]}"
         SUITE_EXIT_CODE=$?
         ;;
+    unit)
+        PHPUNIT_CONFIG_FILE="Build/phpunit/UnitTests.xml"
+        COMMAND=(vendor/bin/phpunit -c ${PHPUNIT_CONFIG_FILE} "$@")
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name unit-${SUFFIX} ${XDEBUG_MODE} -e XDEBUG_CONFIG="${XDEBUG_CONFIG}" ${IMAGE_PHP} "${COMMAND[@]}"
+        SUITE_EXIT_CODE=$?
+        ;;
+    unitRandom)
+        PHPUNIT_CONFIG_FILE="Build/phpunit/UnitTests.xml"
+        COMMAND=(vendor/bin/phpunit -c ${PHPUNIT_CONFIG_FILE} --order-by=random ${PHPUNIT_RANDOM} "$@")
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name unit-random-${SUFFIX} ${XDEBUG_MODE} -e XDEBUG_CONFIG="${XDEBUG_CONFIG}" ${IMAGE_PHP} "${COMMAND[@]}"
+        SUITE_EXIT_CODE=$?
+        ;;
     update)
         # pull typo3/core-testing-* versions of those ones that exist locally
         echo "> pull ghcr.io/typo3/core-testing-* versions of those ones that exist locally"

--- a/Build/phpunit/UnitTests.xml
+++ b/Build/phpunit/UnitTests.xml
@@ -1,0 +1,43 @@
+<phpunit
+        backupGlobals="true"
+        cacheResult="false"
+        colors="true"
+        convertDeprecationsToExceptions="true"
+        convertErrorsToExceptions="true"
+        convertWarningsToExceptions="true"
+        convertNoticesToExceptions="true"
+        forceCoversAnnotation="false"
+        processIsolation="false"
+        stopOnError="false"
+        stopOnFailure="false"
+        stopOnIncomplete="false"
+        stopOnSkipped="false"
+        verbose="false"
+        beStrictAboutTestsThatDoNotTestAnything="false"
+        failOnWarning="true"
+        failOnRisky="true"
+>
+    <testsuites>
+        <testsuite name="Unit tests">
+            <!--
+                This path either needs an adaption in extensions, or an extension's
+                test location path needs to be given to phpunit.
+            -->
+            <directory>../../tests/Unit/</directory>
+        </testsuite>
+    </testsuites>
+    <!-- @todo: change tag to 'coverage' when TF requires phpunit > 9 -->
+    <filter>
+        <!-- @todo: change tag to 'include' when TF requires phpunit > 9 -->
+        <whitelist>
+            <!--
+                This path needs an adaption in extensions, when coverage statistics are wanted.
+            -->
+            <directory>../../src/</directory>
+        </whitelist>
+    </filter>
+    <php>
+        <ini name="display_errors" value="1" />
+        <ini name="error_reporting" value="E_ALL"/>
+    </php>
+</phpunit>

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,9 @@
         "friendsofphp/php-cs-fixer": "^3.68.1",
         "phpstan/phpstan": "^2.1.2",
         "phpstan/phpdoc-parser": "^1.30.1",
-        "bnf/phpstan-psr-container": "^1.1.0"
+        "bnf/phpstan-psr-container": "^1.1.0",
+        "phpunit/phpunit": "9.6.22",
+        "phpstan/phpstan-phpunit": "^2.0.4"
     },
     "autoload": {
         "psr-4": {
@@ -36,6 +38,7 @@
     },
     "autoload-dev": {
         "psr-4": {
+            "SBUERK\\TestFixtureExtensionAdopter\\Tests\\Unit\\": "tests/Unit",
             "SBUERK\\PHPStan\\": "Build/phpstan/src/"
         }
     }

--- a/tests/Unit/DummyTest.php
+++ b/tests/Unit/DummyTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SBUERK\TestFixtureExtensionAdopter\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use SBUERK\TestFixtureExtensionAdopter\Dummy;
+
+final class DummyTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function dummyInstanceCanBeCreatedUsingNewKeyWord(): void
+    {
+        self::assertIsObject(new Dummy());
+    }
+}


### PR DESCRIPTION
To provide the ability for testing code directly
when adding it, unit testing infrastructure is
added based on `PHPUnit`, integrated into the
`Build/Scripts/runTests.sh` dispatcher and also
enabled as GitHub action workflow.

```shell
composer require --dev \
    "phpunit/phpunit":"9.6.22" \
    "phpstan/phpstan-phpunit":"^2.0.4"
```

Resolves: #4
Releases: main
