### PR TITLE
[FEATURE] Adopt autoload configuration from fixture package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /.idea/
 /vendor/
 /composer.lock
+/tmp

--- a/Build/php-cs-fixer/config.php
+++ b/Build/php-cs-fixer/config.php
@@ -60,6 +60,7 @@ return (new \PhpCsFixer\Config())
             ->ignoreVCSIgnored(true)
             ->in([
                 __DIR__ . '/../../src',
+                __DIR__ . '/../../tmpl',
                 __DIR__ . '/../../Build',
                 __DIR__ . '/../../tests',
             ])

--- a/Build/php-cs-fixer/config.php
+++ b/Build/php-cs-fixer/config.php
@@ -61,7 +61,7 @@ return (new \PhpCsFixer\Config())
             ->in([
                 __DIR__ . '/../../src',
                 __DIR__ . '/../../Build',
-                __DIR__ . '/../../tests'
+                __DIR__ . '/../../tests',
             ])
     )
     ->setRiskyAllowed(true)

--- a/Build/php-cs-fixer/config.php
+++ b/Build/php-cs-fixer/config.php
@@ -61,6 +61,7 @@ return (new \PhpCsFixer\Config())
             ->in([
                 __DIR__ . '/../../src',
                 __DIR__ . '/../../Build',
+                __DIR__ . '/../../tests'
             ])
     )
     ->setRiskyAllowed(true)

--- a/Build/phpstan/phpstan.neon
+++ b/Build/phpstan/phpstan.neon
@@ -1,6 +1,12 @@
 includes:
-  - phpstan-baseline.neon
+  - ../../vendor/composer/composer/phpstan/rules.neon
   - ../../vendor/bnf/phpstan-psr-container/extension.neon
+  - ../../vendor/phpstan/phpstan-phpunit/extension.neon
+  - ../../vendor/phpstan/phpstan-deprecation-rules/rules.neon
+  - ../../vendor/phpstan/phpstan-symfony/extension.neon
+  - ../../vendor/composer/pcre/extension.neon
+  - ../../vendor/phpstan/phpstan-symfony/rules.neon
+  - phpstan-baseline.neon
 
 services:
   -
@@ -17,7 +23,15 @@ parameters:
   # Use local .cache dir instead of /tmp
   tmpDir: ../../.cache/phpstan
 
-  level: max
+  level: 9
+
+  treatPhpDocTypesAsCertain: false
 
   paths:
     - ../../src/
+    - ../../tmpl/
+
+  ignoreErrors:
+    # unused parameters
+    - '~^Constructor of class SBUERK\\FixturePackages\\Composer\\Repository\\FixturePathRepository has an unused parameter \$dispatcher\.$~'
+    - '~^Constructor of class SBUERK\\FixturePackages\\Composer\\Repository\\FixturePathRepository has an unused parameter \$httpDownloader\.$~'

--- a/Build/phpstan/phpstan.neon
+++ b/Build/phpstan/phpstan.neon
@@ -9,7 +9,7 @@ services:
       # treatPhpDocTypesAsCertain is explicitly disabled as long as we have ignored errors
       # in our baseline, as that we MUST not trust doc types 100%.
       # We can switch to the global parameter `%treatPhpDocTypesAsCertain%` once that's fixed.
-      treatPhpDocTypesAsCertain: true
+      treatPhpDocTypesAsCertain: false
     tags:
       - phpstan.rules.rule
 
@@ -17,7 +17,7 @@ parameters:
   # Use local .cache dir instead of /tmp
   tmpDir: ../../.cache/phpstan
 
-  level: 9
+  level: max
 
   paths:
     - ../../src/

--- a/Build/phpunit/UnitTests.xml
+++ b/Build/phpunit/UnitTests.xml
@@ -1,43 +1,40 @@
+<?xml version="1.0"?>
 <phpunit
-        backupGlobals="true"
-        cacheResult="false"
-        colors="true"
-        convertDeprecationsToExceptions="true"
-        convertErrorsToExceptions="true"
-        convertWarningsToExceptions="true"
-        convertNoticesToExceptions="true"
-        forceCoversAnnotation="false"
-        processIsolation="false"
-        stopOnError="false"
-        stopOnFailure="false"
-        stopOnIncomplete="false"
-        stopOnSkipped="false"
-        verbose="false"
-        beStrictAboutTestsThatDoNotTestAnything="false"
-        failOnWarning="true"
-        failOnRisky="true"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+  backupGlobals="true"
+  cacheResult="false"
+  colors="true"
+  convertDeprecationsToExceptions="true"
+  convertErrorsToExceptions="true"
+  convertWarningsToExceptions="true"
+  convertNoticesToExceptions="true"
+  forceCoversAnnotation="false"
+  processIsolation="false"
+  stopOnError="false"
+  stopOnFailure="false"
+  stopOnIncomplete="false"
+  stopOnSkipped="false"
+  verbose="false"
+  beStrictAboutTestsThatDoNotTestAnything="false"
+  failOnWarning="true"
+  failOnRisky="true"
 >
-    <testsuites>
-        <testsuite name="Unit tests">
-            <!--
-                This path either needs an adaption in extensions, or an extension's
-                test location path needs to be given to phpunit.
-            -->
-            <directory>../../tests/Unit/</directory>
-        </testsuite>
-    </testsuites>
-    <!-- @todo: change tag to 'coverage' when TF requires phpunit > 9 -->
-    <filter>
-        <!-- @todo: change tag to 'include' when TF requires phpunit > 9 -->
-        <whitelist>
-            <!--
-                This path needs an adaption in extensions, when coverage statistics are wanted.
-            -->
-            <directory>../../src/</directory>
-        </whitelist>
-    </filter>
-    <php>
-        <ini name="display_errors" value="1" />
-        <ini name="error_reporting" value="E_ALL"/>
-    </php>
+  <coverage>
+    <include>
+      <directory>../../src/</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Unit tests">
+      <directory>../../tests/Unit/</directory>
+    </testsuite>
+    <testsuite name="Integration tests">
+      <directory>../../tests/Integration/</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <ini name="display_errors" value="1"/>
+    <ini name="error_reporting" value="E_ALL"/>
+  </php>
 </phpunit>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,176 @@
-TYPO3 Test Fixture Extension Adopter
-====================================
+# Composer plugin `sbuerk/fixture-packages`
 
-# Mission
+Package `sbuerk/fixture-packages` provides a development context composer plugin,
+which allows to define paths to scan for composer packages and adopt `autoload`
+registrations from package as `autoload-dev` registration of the root package,
+effectly removing the need to register each package autoload manually to have
+autoloading in place, for example when writing unit, functional or integration
+tests based on [PHPUnit](https://github.com/sebastianbergmann/phpunit).
+
+## Contents
+
+- [Installation](#installation)
+- [Configuration](#configuration)
+- [Generated files](#generated-files)
+  - [Use generated `FixturePackages`](#use-generated-fixturepackages)
+    - [[TYPO3] Functional testing with typo3/testing-framework](#typo3-functional-testing-with-typo3testing-framework)
+
+## Installation
+
+> [!NOTE]
+> The plugin automatically works after the installation and updates the namespace
+> registration when dumping autoloader information.
+
+> [!TIP]
+> You can enforce regeneration of autoload information, for example after adding
+> or removing packages to/from one of the [configured](#Configuration) fixture
+> paths by using `composer dump-autoload`. This is also use-full if autoload
+> configuration for registered packages has changed, for example adding additonal
+> namespaces.
+
+> ![IMPORTANT]
+> This plugin only registers fixture package autoload configuration as root package
+> autoload-dev configuration when executed in `--dev (DEFAULT)` mode, doing nothing
+> when `--no-dev` is used or has been used.
+
+**Set config to allow plugin**
+
+```shell
+composer config allow-plugins.sbuerk/fixture-packages true
+```
+
+**Require composer plugin as development dependency**
+
+> [!IMPORTANT]
+> The plugin adds additional package namespaces as development dependencies to
+> simplify development setups, mainly for test execution, and usually no need
+> to have it in production installations and **should not be** installed as
+> dependency, special for packages which are libraries, bundles, extensions,
+> plugins and itself required by projects or other packages.
+
+```shell
+composer require --dev "sbuerk/fixture-packages"
+```
+
+**One-liner**
+
+```shell
+composer config allow-plugins.sbuerk/fixture-packages true && \
+  composer require --dev "sbuerk/fixture-packages"
+```
+
+## Configuration
+
+[composer](https://getcomposer.org) restricts places for custom configuration within the `composer.json`
+schema to the extra-section and is used to configure paths to scan for extensions:
+
+```json
+{
+  "extra": {
+    "sbuerk/fixture-packages": [
+      "multiple-packages-in-folder/*",
+      "pattern-matching/*/matching/same/subpath-in-multiple-places/*",
+      "packages/direct-package-path-containing-a-composer.json"
+    ]
+  }
+}
+```
+
+## Generated files
+
+This plugin create two files:
+
+| File                               | Description                                                                |
+|------------------------------------|----------------------------------------------------------------------------|
+| vendor/sbuerk/fixture-packages.php | Returns an array with fixture package information.                         |
+| vendor/sbuerk/FixturePackages.php  | Provides `FixturePackages` to work with fixture package information state. |
+
+> [!NOTE]
+> These files are not generated to be used casually, but provides
+> a helping hand to be used to integrate it eventually into some
+> framework / testing-framework, for example to allow dynamically
+> load extensions, plugings, bundles or how the framework calls
+> them.
+
+### Use generated `FixturePackages`
+
+The `FixturePackages` class provides conveniant way to work with
+the data and provess additional tasks, for example using within
+[typo3/testing-framework](https://github.com/typo3/testing-framework)
+bases functional tests to register them and use them by composer
+package name as extension to load in functional tests.
+
+#### [TYPO3] Functional testing with typo3/testing-framework
+
+The `FixturePackages` class provides a method to adopt fixture packages,
+which are valid TYPO3 extensions into the `ComposerPackageManager` which
+allows to use the extension-key or composer package name to configure the
+extension to load in functional tests.
+
+This is not done automatically yet, but can be done easily by copy & paste
+
+```php
+/**
+ * Automatically add fixture extensions to the `typo3/testing-framework`
+ * {@see \TYPO3\TestingFramework\Composer\ComposerPackageManager} to
+ * allow composer package name or extension keys of fixture extension in
+ * {@see \TYPO3\TestingFramework\Core\Functional\FunctionalTestCase::$testExtensionToLoad}.
+ */
+if (class_exists(\SBUERK\FixturePackages::class)) {
+    (new \SBUERK\FixturePackages())->adoptFixtureExtensions();
+}
+```
+
+into the `FunctionalTestBootstrap.php` file within your extension or project.
+
+> [!TIP]
+> If you do not have the functional bootstrap copied from the testing-framework,
+> you should do that prior to add the snippet. Read the file header along with
+> `FunctionalTests.xml` PHPUnit configuration file already stating that these
+> files **should* be copied anyway.
+
+Usually, the bootstrap file for functional tests looks similar to the following:
+
+```php
+<?php 
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+/**
+ * Boilerplate for a functional test phpunit boostrap file.
+ *
+ * This file is loosely maintained within TYPO3 testing-framework, extensions
+ * are encouraged to not use it directly, but to copy it to an own place,
+ * usually in parallel to a FunctionalTests.xml file.
+ *
+ * This file is defined in FunctionalTests.xml and called by phpunit
+ * before instantiating the test suites.
+ */
+(static function () {
+
+    /**
+     * Automatically add fixture extensions to the `typo3/testing-framework`
+     * {@see \TYPO3\TestingFramework\Composer\ComposerPackageManager} to
+     * allow composer package name or extension keys of fixture extension in
+     * {@see \TYPO3\TestingFramework\Core\Functional\FunctionalTestCase::$testExtensionToLoad}.
+     */
+    if (class_exists(\SBUERK\FixturePackages::class)) {
+        (new \SBUERK\FixturePackages())->adoptFixtureExtensions();
+    }
+
+    $testbase = new \TYPO3\TestingFramework\Core\Testbase();
+    $testbase->defineOriginalRootPath();
+    $testbase->createDirectory(ORIGINAL_ROOT . 'typo3temp/var/tests');
+    $testbase->createDirectory(ORIGINAL_ROOT . 'typo3temp/var/transient');
+})();
+```

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "sbuerk/typo3-test-fixture-extension-adopter",
+    "name": "sbuerk/fixture-packages",
     "description": "Helps working with TYPO3 test fixture extensions with typo3/testing-framework functional tests",
     "type": "composer-plugin",
     "license": "GPL-2.0-or-later",
@@ -11,12 +11,11 @@
         }
     ],
     "keywords": [
-        "typo3",
         "testing",
-        "tests",
-        "functional",
         "fixture",
-        "extension"
+        "packages",
+        "typo3",
+        "typo3/testing-framework"
     ],
     "require": {
         "php": "^7.4 || ^8.0",
@@ -29,17 +28,26 @@
         "phpstan/phpdoc-parser": "^1.30.1",
         "bnf/phpstan-psr-container": "^1.1.0",
         "phpunit/phpunit": "9.6.22",
-        "phpstan/phpstan-phpunit": "^2.0.4"
+        "phpstan/phpstan-phpunit": "^2.0.4",
+        "phpstan/phpstan-symfony": "^2.0.2",
+        "phpstan/phpstan-deprecation-rules": "^2.0.1"
     },
     "autoload": {
         "psr-4": {
-            "SBUERK\\TestFixtureExtensionAdopter\\": "src/"
+            "SBUERK\\FixturePackages\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "SBUERK\\TestFixtureExtensionAdopter\\Tests\\Unit\\": "tests/Unit",
+            "SBUERK\\FixturePackages\\Tests\\Unit\\": "tests/Unit",
+            "SBUERK\\FixturePackages\\Tests\\Integration\\": "tests/Integration",
             "SBUERK\\PHPStan\\": "Build/phpstan/src/"
-        }
+        },
+        "classmap": [
+            "tmpl/"
+        ]
+    },
+    "extra": {
+        "class": "SBUERK\\FixturePackages\\Plugin"
     }
 }

--- a/src/Composer/Repository/FixturePathRepository.php
+++ b/src/Composer/Repository/FixturePathRepository.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace SBUERK\FixturePackages\Composer\Repository;
+
+use Composer\Config;
+use Composer\EventDispatcher\EventDispatcher;
+use Composer\IO\IOInterface;
+use Composer\Json\JsonFile;
+use Composer\Package\Loader\ArrayLoader;
+use Composer\Package\Version\VersionGuesser;
+use Composer\Package\Version\VersionParser;
+use Composer\Pcre\Preg;
+use Composer\Repository\ArrayRepository;
+use Composer\Repository\ConfigurableRepositoryInterface;
+use Composer\Repository\PathRepository;
+use Composer\Util\Filesystem;
+use Composer\Util\Git as GitUtil;
+use Composer\Util\HttpDownloader;
+use Composer\Util\Platform;
+use Composer\Util\ProcessExecutor;
+use Composer\Util\Url;
+
+/**
+ * Custom repository implementation based on {@see PathRepository} with minor changes.
+ *
+ * - git `feature_pretty_version` version is not added as additional package.
+ * - uses fixture-path instead of path as repo name prefix and distType.
+ *
+ * This repository is not added as general composer repository type, which means it cannot be used directly within the
+ * composer.json repositories section and is used to operate for the `extra->testing-framework->fixture-package-paths`.
+ */
+final class FixturePathRepository extends ArrayRepository implements ConfigurableRepositoryInterface
+{
+    private ArrayLoader $loader;
+    private VersionGuesser $versionGuesser;
+    private ProcessExecutor $process;
+    private string $url;
+
+    /**
+     * @var array{url: string, options?: array{symlink?: bool, reference?: string, relative?: bool, versions?: array<string, string>}}
+     */
+    private array $repoConfig;
+
+    /**
+     * @var array{symlink?: bool, reference?: string, relative?: bool, versions?: array<string, string>}
+     */
+    private $options;
+
+    /**
+     * Initializes path repository.
+     *
+     * @param array{url?: string, options?: array{symlink?: bool, reference?: string, relative?: bool, versions?: array<string, string>}} $repoConfig
+     */
+    public function __construct(array $repoConfig, IOInterface $io, Config $config, ?HttpDownloader $httpDownloader = null, ?EventDispatcher $dispatcher = null, ?ProcessExecutor $process = null)
+    {
+        if (!isset($repoConfig['url'])) {
+            throw new \RuntimeException('You must specify the `url` configuration for the path repository');
+        }
+
+        $this->loader = new ArrayLoader(null, true);
+        $this->url = Platform::expandPath($repoConfig['url']);
+        $this->process = $process ?? new ProcessExecutor($io);
+        $this->versionGuesser = new VersionGuesser($config, $this->process, new VersionParser(), $io);
+        $this->repoConfig = $repoConfig;
+        $this->options = $repoConfig['options'] ?? [];
+        if (!isset($this->options['relative'])) {
+            $filesystem = new Filesystem();
+            $this->options['relative'] = !$filesystem->isAbsolutePath($this->url);
+        }
+
+        parent::__construct();
+    }
+
+    public function getRepoName(): string
+    {
+        return 'fixture-path repo (' . Url::sanitize($this->repoConfig['url']) . ')';
+    }
+
+    public function getRepoConfig(): array
+    {
+        return $this->repoConfig;
+    }
+
+    /**
+     * Initializes path repository.
+     *
+     * This method will basically read the folder and add the found package.
+     */
+    protected function initialize(): void
+    {
+        parent::initialize();
+
+        $urlMatches = $this->getUrlMatches();
+
+        if (empty($urlMatches)) {
+            if (Preg::isMatch('{[*{}]}', $this->url)) {
+                $url = $this->url;
+                while (Preg::isMatch('{[*{}]}', $url)) {
+                    $url = dirname($url);
+                }
+                // the parent directory before any wildcard exists, so we assume it is correctly configured but simply empty
+                if (is_dir($url)) {
+                    return;
+                }
+            }
+
+            throw new \RuntimeException('The `url` supplied for the path (' . $this->url . ') repository does not exist');
+        }
+
+        foreach ($urlMatches as $url) {
+            $path = realpath($url) . DIRECTORY_SEPARATOR;
+            $composerFilePath = $path . 'composer.json';
+
+            if (!file_exists($composerFilePath)) {
+                continue;
+            }
+
+            $json = file_get_contents($composerFilePath);
+            $package = JsonFile::parseJson($json ?: null, $composerFilePath);
+            if (!is_array($package)) {
+                $package = [];
+            }
+            $package['dist'] = [
+                'type' => 'fixture-path',
+                'url' => $url,
+            ];
+            $reference = $this->options['reference'] ?? 'auto';
+            if ($reference === 'none') {
+                $package['dist']['reference'] = null;
+            } elseif ($reference === 'config' || $reference === 'auto') {
+                $package['dist']['reference'] = hash('sha1', $json . serialize($this->options));
+            }
+
+            // copy symlink/relative options to transport options
+            $package['transport-options'] = array_intersect_key($this->options, ['symlink' => true, 'relative' => true]);
+            // use the version provided as option if available
+            if (isset($package['name'], $this->options['versions'][$package['name']])) {
+                $package['version'] = $this->options['versions'][$package['name']];
+            }
+
+            // carry over the root package version if this path repo is in the same git repository as root package
+            if (!isset($package['version']) && ($rootVersion = Platform::getEnv('COMPOSER_ROOT_VERSION'))) {
+                if (
+                    $this->process->execute(['git', 'rev-parse', 'HEAD'], $ref1, $path) === 0
+                    && $this->process->execute(['git', 'rev-parse', 'HEAD'], $ref2) === 0
+                    && $ref1 === $ref2
+                ) {
+                    $package['version'] = $this->versionGuesser->getRootVersionFromEnv();
+                }
+            }
+
+            $output = '';
+            if ($reference === 'auto' && is_dir($path . DIRECTORY_SEPARATOR . '.git') && $this->process->execute(array_merge(['git', 'log', '-n1', '--pretty=%H'], GitUtil::getNoShowSignatureFlags($this->process)), $output, $path) === 0) {
+                $package['dist']['reference'] = trim(is_string($output) ? $output : '');
+            }
+
+            if (!isset($package['version'])) {
+                $versionData = $this->versionGuesser->guessVersion($package, $path);
+                if (is_array($versionData) && $versionData['pretty_version']) {
+                    // Composer path repository adds additional package for the feature pretty version, which we does
+                    // not need for the fixture packages repository. Even more, it would lead to inconsistencies, and
+                    // is therefore commented out here, but left to investigate eventually later refactorings to adopt.
+                    //
+                    //// if there is a feature branch detected, we add a second packages with the feature branch version
+                    //if (!empty($versionData['feature_pretty_version'])) {
+                    //    $package['version'] = $versionData['feature_pretty_version'];
+                    //    $this->addPackage($this->loader->load($package));
+                    //}
+
+                    $package['version'] = $versionData['pretty_version'];
+                } else {
+                    $package['version'] = 'dev-main';
+                }
+            }
+
+            try {
+                $this->addPackage($this->loader->load($package));
+            } catch (\Exception $e) {
+                throw new \RuntimeException('Failed loading the package in ' . $composerFilePath, 0, $e);
+            }
+        }
+    }
+
+    /**
+     * Get a list of all (possibly relative) path names matching given url (supports globbing).
+     *
+     * @return string[]
+     */
+    private function getUrlMatches(): array
+    {
+        $flags = GLOB_MARK | GLOB_ONLYDIR;
+
+        if (defined('GLOB_BRACE')) {
+            $flags |= GLOB_BRACE;
+        } elseif (str_contains($this->url, '{')   || str_contains($this->url, '}')) {
+            throw new \RuntimeException('The operating system does not support GLOB_BRACE which is required for the url ' . $this->url);
+        }
+
+        // Ensure environment-specific path separators are normalized to URL separators
+        return array_map(static function ($val): string {
+            return rtrim(str_replace(DIRECTORY_SEPARATOR, '/', $val), '/');
+        }, (array)(glob($this->url, $flags) ?: []));
+    }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace SBUERK\FixturePackages;
+
+use Composer\Composer;
+use Composer\EventDispatcher\EventSubscriberInterface;
+use Composer\IO\IOInterface;
+use Composer\Plugin\PluginInterface;
+use Composer\Script\Event;
+use Composer\Script\ScriptEvents;
+use SBUERK\FixturePackages\Plugin\FixturePackagesService;
+
+/**
+ * Provides the package composer plugin implementation and is the starting point.
+ */
+final class Plugin implements PluginInterface, EventSubscriberInterface
+{
+    /**
+     * @var array<string, bool>
+     */
+    private $handledEvents = [];
+
+    private ?FixturePackagesService $testFixtureExtensionService = null;
+
+    /**
+     * {@inheritDoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            ScriptEvents::PRE_AUTOLOAD_DUMP => [
+                'listen',
+            ],
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function activate(Composer $composer, IOInterface $io): void
+    {
+        $io->write(
+            '<info>>> Fixture package adopter plugin activated.</info>',
+            true,
+            IOInterface::DEBUG
+        );
+        $composer->getEventDispatcher()->addSubscriber($this);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function deactivate(Composer $composer, IOInterface $io): void
+    {
+        // noop - required by PluginInterface
+        $io->write(
+            '<info>>> Fixture package adopter plugin deactivate.</info>',
+            true,
+            IOInterface::DEBUG
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function uninstall(Composer $composer, IOInterface $io): void
+    {
+        // noop - required by PluginInterface
+        $io->write(
+            '<info>>> Fixture package adopter plugin uninstalled.</info>',
+            true,
+            IOInterface::DEBUG
+        );
+    }
+
+    /**
+     * Listens to Composer events.
+     *
+     * This method is very minimalist on purpose. We want to load the actual
+     * implementation only after updating the Composer packages so that we get
+     * the updated version (if available).
+     *
+     * @param Event $event The Composer event.
+     */
+    public function listen(Event $event): void
+    {
+        if (!empty($this->handledEvents[$event->getName()])) {
+            return;
+        }
+        $this->handledEvents[$event->getName()] = true;
+        // Plugin has been uninstalled
+        if (!file_exists(__FILE__) || !file_exists(__DIR__ . '/Plugin/FixturePackagesService.php')) {
+            return;
+        }
+        // Load the implementation only after updating Composer so that we get
+        // the new version of the plugin when a new one was installed
+        $this->testFixtureExtensionService = $this->testFixtureExtensionService ?? new FixturePackagesService();
+        switch ($event->getName()) {
+            case ScriptEvents::PRE_AUTOLOAD_DUMP:
+                $this->testFixtureExtensionService->adopt(
+                    $event->getComposer(),
+                    $event->getIO(),
+                    $event->isDevMode()
+                );
+                break;
+        }
+    }
+}

--- a/src/Plugin/Config.php
+++ b/src/Plugin/Config.php
@@ -1,0 +1,248 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace SBUERK\TestFixtureExtensionAdopter\Plugin;
+
+use Composer\Composer;
+use Composer\IO\IOInterface;
+use Composer\IO\NullIO;
+use Composer\Package\RootPackageInterface;
+use Composer\Util\Filesystem;
+
+final class Config
+{
+    public const FLAG_PATHS_DEFAULT = 0;
+    public const FLAG_PATHS_RELATIVE = 1;
+
+    /**
+     * @var array<int|string, mixed>
+     */
+    protected array $config;
+    protected string $baseDir;
+
+    private static ?self $instance = null;
+
+    public function __construct(
+        string $baseDir
+    ) {
+        $this->baseDir = $this->normalizePath($baseDir);
+        $this->config = [
+            'fixture-extension-paths' => [],
+        ];
+    }
+
+    /**
+     * Merges new config values with the existing ones (overriding)
+     *
+     * @param array<int|string, mixed> $config
+     */
+    public function merge(array $config): self
+    {
+        // Override defaults with given config
+        if (is_array($config['typo3/testing-framework'] ?? null)) {
+            foreach ($config['typo3/testing-framework'] as $key => $value) {
+                if ($key === 'fixture-extension-paths' && is_array($value)) {
+                    $this->config['fixture-extension-paths'] = $value;
+                }
+            }
+        }
+        return $this;
+    }
+
+    /**
+     * @param int-mask-of<self::FLAG_*> $flags
+     * @return string[]
+     */
+    public function fixtureExtensionPaths(int $flags = self::FLAG_PATHS_DEFAULT): array
+    {
+        return $this->get('fixture-extension-paths', $flags);
+    }
+
+    /**
+     * Returns a setting
+     *
+     * @param int-mask-of<self::FLAG_*> $flags See class FLAG_* constants.
+     * @return ($key is 'fixture-extension-paths' ? string[] : null)
+     */
+    public function get(string $key, int $flags = self::FLAG_PATHS_DEFAULT)
+    {
+        switch ($key) {
+            case 'fixture-extension-paths':
+                /** @var string[] $paths */
+                $paths = $this->config['fixture-extension-paths'] ?? [];
+                return $this->processFixtureExtensionPaths($paths, $flags);
+            default:
+                return null;
+        }
+    }
+
+    /**
+     * @param int-mask-of<self::FLAG_*> $flags
+     *
+     * @return array{}|array{config: non-empty-array<string, array<string>|null>}
+     */
+    public function all(int $flags = self::FLAG_PATHS_DEFAULT)
+    {
+        $all = [];
+        foreach (array_keys($this->config) as $key) {
+            $all['config'][(string)$key] = $this->get((string)$key, $flags);
+        }
+        return $all;
+    }
+
+    /**
+     * @return array{config: array<int|string, mixed>}
+     */
+    public function raw(): array
+    {
+        return [
+            'config' => $this->config,
+        ];
+    }
+
+    /**
+     * @param string $key
+     * @return bool
+     */
+    public function has(string $key): bool
+    {
+        return array_key_exists($key, $this->config);
+    }
+
+    /**
+     * @param string[] $paths
+     * @param int-mask-of<self::FLAG_*> $flags
+     *
+     * @return string[]
+     */
+    protected function processFixtureExtensionPaths(array $paths, int $flags = 0): array
+    {
+        $relativePaths = $this->isRelativePathsFlag($flags);
+        $paths = array_values($paths);
+        array_walk($paths, fn(string $value): string => rtrim(($relativePaths ? $value : $this->realpath($value)), '/\\'));
+        return $paths;
+    }
+
+    /**
+     * @param int-mask-of<self::FLAG_*> $flags
+     *
+     * @return bool
+     */
+    private function isRelativePathsFlag(int $flags): bool
+    {
+        return ($flags & self::FLAG_PATHS_RELATIVE) === 1;
+    }
+
+    /**
+     * Turns relative paths in absolute paths without realpath()
+     *
+     * Since the dirs might not exist yet we can not call realpath or it will fail.
+     */
+    private function realpath(string $path): string
+    {
+        if ($path === '') {
+            return $this->baseDir;
+        }
+        $path = $this->normalizePath($path);
+        if ($path[0] === '/' || (!empty($path[1]) && $path[1] === ':')) {
+            return $path;
+        }
+
+        return $this->baseDir . '/' . $path;
+    }
+
+    private function normalizePath(string $path): string
+    {
+        $path = (new Filesystem())->normalizePath($path);
+        if ($path === '/' || rtrim($path, '/') === '') {
+            return '/';
+        }
+        return rtrim($path, '/');
+    }
+
+    public static function load(Composer $composer, ?IOInterface $io = null): self
+    {
+        if (self::$instance === null) {
+            $io = $io ?? new NullIO();
+            $baseDir = self::extractBaseDir($composer->getConfig());
+            self::$instance = (new self($baseDir))->merge(self::handleRootPackageExtraConfig($io, $composer->getPackage()));
+        }
+        return self::$instance;
+    }
+
+    /**
+     * @param IOInterface $io
+     * @param RootPackageInterface $rootPackage
+     * @return array<int|string, mixed>
+     */
+    private static function handleRootPackageExtraConfig(IOInterface $io, RootPackageInterface $rootPackage): array
+    {
+        $rootPackageExtraConfig = $rootPackage->getExtra();
+        if (!isset($rootPackageExtraConfig['typo3/testing-framework'])
+            || !is_array($rootPackageExtraConfig['typo3/testing-framework'])
+            || !isset($rootPackageExtraConfig['typo3/testing-framework']['fixture-extension-paths'])
+        ) {
+            return $rootPackageExtraConfig;
+        }
+        if (!is_array($rootPackageExtraConfig['typo3/testing-framework']['fixture-extension-paths'])) {
+            $io->writeError(sprintf(
+                '<warning>extra->typo3/testing-framework/fixture-extension-paths must be an array, "%s" given.</warning>',
+                gettype($rootPackageExtraConfig['typo3/testing-framework']['fixture-extension-paths'])
+            ));
+            unset($rootPackageExtraConfig['typo3/testing-framework']['fixture-extension-paths']);
+            return $rootPackageExtraConfig;
+        }
+        $fixtureExtensionPaths = $rootPackageExtraConfig['typo3/testing-framework']['fixture-extension-paths'];
+        if (empty($fixtureExtensionPaths)) {
+            return $rootPackageExtraConfig;
+        }
+        $basePath = '/fake/root';
+        $config = new self($basePath);
+        $validPaths = [];
+        foreach ($fixtureExtensionPaths as $path) {
+            if (!is_string($path)) {
+                continue;
+            }
+            $normalizedPath = $config->normalizePath($path);
+            $realPath = $config->normalizePath($config->realpath($normalizedPath));
+            if (!str_starts_with($realPath, $basePath . '/')) {
+                $io->writeError(sprintf(
+                    '<warning>Test fixture extension path must be a subdirectory of Composer root directory. Skip "%s".</warning>',
+                    $path
+                ));
+                continue;
+            }
+            $validPaths[] = $path;
+        }
+        $rootPackageExtraConfig['typo3/testing-framework']['fixture-extension-paths'] = $validPaths;
+        return $rootPackageExtraConfig;
+    }
+
+    /**
+     * @param \Composer\Config $config
+     * @return non-empty-string
+     */
+    protected static function extractBaseDir(\Composer\Config $config)
+    {
+        $reflectionClass = new \ReflectionClass($config);
+        $reflectionProperty = $reflectionClass->getProperty('baseDir');
+        $reflectionProperty->setAccessible(true);
+        /** @var non-empty-string $value */
+        $value = $reflectionProperty->getValue($config);
+        return $value;
+    }
+}

--- a/src/Plugin/FixturePackagesService.php
+++ b/src/Plugin/FixturePackagesService.php
@@ -1,0 +1,242 @@
+<?php
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace SBUERK\FixturePackages\Plugin;
+
+use Composer\Composer;
+use Composer\IO\IOInterface;
+use Composer\Json\JsonFile;
+use Composer\Package\PackageInterface;
+use Composer\Package\RootPackage;
+use Composer\Repository\RepositoryFactory;
+use Composer\Repository\RepositoryInterface;
+use Composer\Repository\RepositoryManager;
+use Composer\Util\Filesystem;
+use SBUERK\FixturePackages\Composer\Repository\FixturePathRepository;
+use SBUERK\FixturePackages\Plugin\Util\AutoloadMerger;
+
+/**
+ * Provides functionalities dealing with configured test fixture packages.
+ */
+final class FixturePackagesService
+{
+    /**
+     * Adopt all configured autoload namespaces from valid fixture test package
+     * as autoload-namespaces for the rootPackage, prefixing namespace paths to
+     * ensure working `composer dump-autoload`.
+     */
+    public function adopt(Composer $composer, IOInterface $io, bool $isDevMode): void
+    {
+        if (!$isDevMode) {
+            // Only adopt namespace in development mode.
+            return;
+        }
+        /** @varr PackageInterface[] $adoptedPackages */
+        $adoptedPackages = [];
+        $config = Config::load($composer, $io);
+        $autoloadMerger = new AutoloadMerger();
+        foreach ($this->getTestFixturePackages($config, $composer, $io, []) as $package) {
+            if ($this->isPackageInstalled($composer, $package)) {
+                $io->write(
+                    sprintf(
+                        '<warning>>> Skipping autoload adopt for package "%s" in "%s", already installed.</warning>',
+                        $package->getName(),
+                        $package->getDistUrl()
+                    )
+                );
+                continue;
+            }
+            $autoloadMerger->mergeAutoloadToAutoloadDev($io, $composer->getPackage(), $package);
+            $adoptedPackages[] = $package;
+        }
+        $this->writeFixturesPackagesStateFile($io, $config, $composer, ...$adoptedPackages);
+    }
+
+    /**
+     * @param Config $config
+     * @param Composer $composer
+     * @param IOInterface $io
+     * @param string[] $allowedPackageTypes
+     * @return PackageInterface[]
+     */
+    private function getTestFixturePackages(Config $config, Composer $composer, IOInterface $io, array $allowedPackageTypes): array
+    {
+        $repositoryManager = $this->createPreparedRepositoryManager($config, $composer, $io);
+        /** @var PackageInterface[] $packages */
+        $packages = [];
+        foreach ($repositoryManager->getRepositories() as $repository) {
+            foreach ($repository->getPackages() as $package) {
+                if ($allowedPackageTypes !== [] && !in_array($package->getType(), $allowedPackageTypes, true)) {
+                    continue;
+                }
+                $packages[] = $package;
+            }
+        }
+        return $packages;
+    }
+
+    /**
+     * Creates a dedictead {@see RepositoryManager} instance and prepare it
+     * only with {@see FixturePathRepository} repositories defined in the
+     * {@see RootPackage::getExtra()} array.
+     */
+    private function createPreparedRepositoryManager(Config $config, Composer $composer, IOInterface $io): RepositoryManager
+    {
+        $repositoryManager = $this->createRepositoryManager($io, $composer);
+        foreach ($config->paths(Config::FLAG_PATHS_RELATIVE) as $path) {
+            $repositoryManager->addRepository($this->createRepositoryForPath($repositoryManager, $composer, $io, $path));
+        }
+        return $repositoryManager;
+    }
+
+    /**
+     * Create fixture-path repository for given path.
+     */
+    private function createRepositoryForPath(RepositoryManager $repositoryManager, Composer $composer, IOInterface $io, string $path): RepositoryInterface
+    {
+        return RepositoryFactory::fromString(
+            $io,
+            $composer->getConfig(),
+            JsonFile::encode([
+                'type' => 'fixture-path',
+                'url' => $path,
+            ]),
+            true,
+            $repositoryManager
+        );
+    }
+
+    /**
+     * For test-fixture package repository we do not need to support all repository types, registered into a
+     * {@see RepositoryManager} instance using {@see RepositoryFactory::manager()} factory method. That help
+     * to avoid unneeded repository types and use customized path repository to avoid duplicated packages
+     * based on feature branch detection.
+     *
+     * {@see FixturePathRepository}.
+     */
+    private function createRepositoryManager(IOInterface $io, Composer $composer): RepositoryManager
+    {
+        $repositoryManager = RepositoryFactory::manager($io, $composer->getConfig());
+        $repositoryManager->setRepositoryClass(
+            'fixture-path',
+            'SBUERK\FixturePackages\Composer\Repository\FixturePathRepository'
+        );
+        return $repositoryManager;
+    }
+
+    /**
+     * Determine if $package is already installed, required using a casual
+     * path repository for example and added as require or require-dev.
+     */
+    private function isPackageInstalled(Composer $composer, PackageInterface $package): bool
+    {
+        $allRequiredPackageNames = [
+            ...array_keys($composer->getPackage()->getRequires()),
+            ...array_keys($composer->getPackage()->getDevRequires()),
+        ];
+        return in_array($package->getName(), $allRequiredPackageNames, true);
+    }
+
+    private function writeFixturesPackagesStateFile(IOInterface $io, Config $pluginConfig, Composer $composer, PackageInterface ...$packages): void
+    {
+        $filesystem = new Filesystem();
+        $vendorPath = $filesystem->normalizePath($composer->getConfig()->get('vendor-dir'));
+        $dataPath = $vendorPath . '/sbuerk';
+        $fixturePackagesFile = $dataPath . '/fixture-packages.php';
+        $data = $this->createExportPackagesArray($pluginConfig, $dataPath, ...$packages);
+        $filesystem->ensureDirectoryExists($dataPath);
+        $filesystem->filePutContentsIfModified(
+            $fixturePackagesFile,
+            '<?php return ' . $this->dumpToPhpCode($data) . ';' . "\n"
+        );
+        if (file_exists($dataPath . '/FixturePackages.php')) {
+            $filesystem->unlink($dataPath . '/FixturePackages.php');
+        }
+        $filesystem->copy(__DIR__ . '/../../tmpl/FixturePackages.php', $dataPath . '/FixturePackages.php');
+        $rootPackage = $composer->getPackage();
+        $devAutoload = $rootPackage->getDevAutoload();
+        if (!isset($devAutoload['classmap']) || !is_array($devAutoload['classmap'])) {
+            $devAutoload['classmap'] = [];
+        }
+        $classFile = $composer->getConfig()->get('vendor-dir', \Composer\Config::RELATIVE_PATHS) . '/sbuerk/FixturePackages.php';
+        $devAutoload['classmap'][] = $classFile;
+        $rootPackage->setDevAutoload($devAutoload);
+    }
+
+    /**
+     * @param PackageInterface ...$packages
+     * @return array<string, array{name: string, type: string, path: string, extra: array<mixed>}>
+     */
+    private function createExportPackagesArray(Config $pluginConfig, string $dataPath, PackageInterface ...$packages): array
+    {
+        $filesystem = new Filesystem();
+        $exportPackages = [];
+        foreach ($packages as $package) {
+            $relativePath = $filesystem->findShortestPath(
+                $dataPath,
+                $pluginConfig->baseDir() . '/' . rtrim((string)$package->getDistUrl(), '/'),
+                true,
+                true
+            );
+            $exportPackages[$package->getName()] = [
+                'name' => $package->getName(),
+                'type' => $package->getType(),
+                'path' => $relativePath,
+                'extra' => $package->getExtra(),
+            ];
+        }
+        return $exportPackages;
+    }
+
+    /**
+     * @param array<int|string, mixed> $array
+     */
+    private function dumpToPhpCode(array $array = [], int $level = 0): string
+    {
+        $lines = "array(\n";
+        $level++;
+
+        foreach ($array as $key => $value) {
+            $lines .= str_repeat('    ', $level);
+            $lines .= is_int($key) ? $key . ' => ' : var_export($key, true) . ' => ';
+
+            if (is_array($value)) {
+                if (!empty($value)) {
+                    $lines .= $this->dumpToPhpCode($value, $level);
+                } else {
+                    $lines .= "array(),\n";
+                }
+            } elseif ($key === 'path' && is_string($value)) {
+                if ((new Filesystem())->isAbsolutePath($value)) {
+                    $lines .= var_export($value, true) . ",\n";
+                } else {
+                    $lines .= '__DIR__ . ' . var_export('/' . $value, true) . ",\n";
+                }
+            } elseif (is_string($value)) {
+                $lines .= var_export($value, true) . ",\n";
+            } elseif (is_bool($value)) {
+                $lines .= ($value ? 'true' : 'false') . ",\n";
+            } elseif (is_null($value)) {
+                $lines .= "null,\n";
+            } else {
+                throw new \UnexpectedValueException('Unexpected type ' . gettype($value));
+            }
+        }
+
+        $lines .= str_repeat('    ', $level - 1) . ')' . ($level - 1 === 0 ? '' : ",\n");
+
+        return $lines;
+    }
+}

--- a/src/Plugin/Util/AutoloadMerger.php
+++ b/src/Plugin/Util/AutoloadMerger.php
@@ -1,0 +1,290 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace SBUERK\FixturePackages\Plugin\Util;
+
+use Composer\IO\IOInterface;
+use Composer\Package\PackageInterface;
+use Composer\Package\RootPackageInterface;
+use Composer\Util\Filesystem;
+
+/**
+ * Provides merging {@see PackageInterface} autoload configuration to
+ * {@see RootPackageInterface} autoload-dev section, prefixing merged
+ * paths with relative package paths.
+ */
+final class AutoloadMerger
+{
+    /**
+     * Merge all {@see PackageInterface::getAutoload()} definitions into {@see RootPackageInterface::setDevAutoload()},
+     * prefixing paths with relative $package paths to ensure correct generated class autoload loader instances by the
+     * `composer dump-autoload` command.
+     *
+     * @todo Consider to lock this to {@see PackageInterface::getDistType()} === 'fixture-path'
+     * @todo Implement `files` namespace merging.
+     * @todo Implement `classmap` namespace merging.
+     */
+    public function mergeAutoloadToAutoloadDev(
+        IOInterface $io,
+        RootPackageInterface $rootPackage,
+        PackageInterface $package
+    ): void {
+        $this->mergeAllNamespaces($io, $rootPackage, $package);
+    }
+
+    /**
+     * Intermediate method to merge all psr-0 and psr-4 autoload namespaces from $package to autoload of the
+     * $rootPackage instance, prefixing with package relative path to ensure correct autoload loader instances
+     * when using `composer dump-autoload`.
+     */
+    private function mergeAllNamespaces(
+        IOInterface $io,
+        RootPackageInterface $rootPackage,
+        PackageInterface $package
+    ): void {
+        $this->mergePsrNamespaces($io, $rootPackage, $package, 'psr-0');
+        $this->mergePsrNamespaces($io, $rootPackage, $package, 'psr-4');
+        $this->mergeSimpleNamespace($io, $rootPackage, $package, 'files');
+        $this->mergeSimpleNamespace($io, $rootPackage, $package, 'classmap');
+    }
+
+    /**
+     * Merge all package autoload psr-o and psr-4 namespaces from `$package` to `$rootPackage` autoload-dev.
+     *
+     * Modifying namespace paths by prefixing $package->getSourceUrl() ensures correct path information,
+     * otherwise composer dump-autoload will create invalid class autoloader instances and paths.
+     */
+    private function mergePsrNamespaces(
+        IOInterface $io,
+        RootPackageInterface $rootPackage,
+        PackageInterface $package,
+        string $psr
+    ): void {
+        if (!$this->isValidPsrNamespace($psr)) {
+            return;
+        }
+        $autoload = $package->getAutoload();
+        if ($autoload === [] || !isset($autoload[$psr]) || !is_array($autoload[$psr])) {
+            return;
+        }
+        foreach ($autoload[$psr] as $namespace => $namespacePaths) {
+            if (!is_string($namespace)) {
+                continue;
+            }
+            if (is_string($namespacePaths)) {
+                $this->mergePsrNamespace(
+                    $io,
+                    $rootPackage,
+                    $package,
+                    $psr,
+                    $namespace,
+                    $namespacePaths
+                );
+                continue;
+            }
+            if (is_array($namespacePaths) && $namespacePaths !== []) {
+                foreach ($namespacePaths as $namespacePath) {
+                    if (!is_string($namespacePath)) {
+                        continue;
+                    }
+                    $this->mergePsrNamespace(
+                        $io,
+                        $rootPackage,
+                        $package,
+                        $psr,
+                        $namespace,
+                        $namespacePath
+                    );
+                }
+            }
+        }
+    }
+
+    /**
+     * Merge single `$namespace` location (`$namespacePath`) for `$psr` (psr-0|psr-4) to as $target autoload-dev
+     * namespace.
+     *
+     * If the namespace for the psr-type already exists, ensure to convert it to an array and provide both or more
+     * paths for the same namespace.
+     *
+     * $namespacePath is prefixed with $package->getSourceUrl(), otherwise path information for composer dump-autoload
+     * would be wrong.
+     *
+     * @todo Consider to make cross psr-type checks.
+     */
+    private function mergePsrNamespace(
+        IOInterface $io,
+        RootPackageInterface $rootPackage,
+        PackageInterface $package,
+        string $psr,
+        string $namespace,
+        string $namespacePath
+    ): void {
+        if (!$this->isValidPsrNamespace($psr)) {
+            return;
+        }
+        $modifiedNamespacePath = $this->modifyPackageNamespacePath($package, $namespacePath);
+        $devAutoload = $rootPackage->getDevAutoload();
+        // Ensure $psr section exists
+        if (!isset($devAutoload[$psr]) || !is_array($devAutoload[$psr])) {
+            $devAutoload[$psr] = [];
+        }
+        // Does not exist yet, simply add autoload namespace as string mapping.
+        if (!isset($devAutoload[$psr][$namespace])) {
+            $devAutoload[$psr][$namespace] = $modifiedNamespacePath;
+            /** @var array{"psr-0"?: array<string, array<string>|string>, "psr-4"?: array<string, array<string>|string>, classmap?: list<string>, files?: list<string>} $devAutoload */
+            $rootPackage->setDevAutoload($devAutoload);
+            $this->writeAdoptedNamespaceMessage($io, $psr, $package->getName(), $namespace, $modifiedNamespacePath);
+            return;
+        }
+        // Namespace exists, but is string mapping. Convert to array.
+        if (is_string($devAutoload[$psr][$namespace])) {
+            if ($devAutoload[$psr][$namespace] === $modifiedNamespacePath) {
+                // same path, skip.
+                /** @var array{"psr-0"?: array<string, array<string>|string>, "psr-4"?: array<string, array<string>|string>, classmap?: list<string>, files?: list<string>} $devAutoload */
+                $rootPackage->setDevAutoload($devAutoload);
+                return;
+            }
+            $devAutoload[$psr][$namespace] = [
+                $devAutoload[$psr][$namespace],
+            ];
+        }
+        if (isset($devAutoload[$psr][$namespace])
+            && is_array($devAutoload[$psr][$namespace])
+            && !in_array($modifiedNamespacePath, $devAutoload[$psr][$namespace], true)
+        ) {
+            $devAutoload[$psr][$namespace][] = $modifiedNamespacePath;
+            /** @var array{"psr-0"?: array<string, array<string>|string>, "psr-4"?: array<string, array<string>|string>, classmap?: list<string>, files?: list<string>} $devAutoload */
+            $rootPackage->setDevAutoload($devAutoload);
+            $this->writeAdoptedNamespaceMessage($io, $psr, $package->getName(), $namespace, $modifiedNamespacePath);
+        }
+    }
+
+    /**
+     * Merge package $type namespaces to $rootPackage, prefixing paths with relative $package path.
+     */
+    private function mergeSimpleNamespace(
+        IOInterface $io,
+        RootPackageInterface $rootPackage,
+        PackageInterface $package,
+        string $type
+    ): void {
+        if (!$this->isValidNamespace($type)) {
+            return;
+        }
+        $autoload = $package->getAutoload();
+        if (!isset($autoload[$type]) || !is_array($autoload[$type]) || $autoload[$type] === []) {
+            $io->debug(sprintf(
+                '<info>Package "%s" does not have an "%s" autoload section. Nothing to merge.</info>',
+                $package->getName(),
+                $type
+            ));
+            return;
+        }
+        $devAutoload = $rootPackage->getDevAutoload();
+        foreach ($autoload[$type] as $namespacePath) {
+            if (!is_string($namespacePath)) {
+                continue;
+            }
+            $modifiedNamespacePath = $this->modifyPackageNamespacePath($package, $namespacePath);
+            if (isset($devAutoload[$type])
+                && is_array($devAutoload[$type])
+                && in_array($modifiedNamespacePath, $devAutoload[$type], true)
+            ) {
+                $io->debug(sprintf(
+                    '<info>Package"%s" namespace "%s" path "%s" already exists in root package as "%s". Skipped.</info>',
+                    $package->getName(),
+                    $type,
+                    $namespacePath,
+                    $modifiedNamespacePath
+                ));
+                continue;
+            }
+            // Ensure that $type section exists
+            if (!isset($devAutoload[$type]) || !is_array($devAutoload[$type])) {
+                $devAutoload[$type] = [];
+            }
+            $devAutoload[$type][] = $modifiedNamespacePath;
+            /** @var array{"psr-0"?: array<string, array<string>|string>, "psr-4"?: array<string, array<string>|string>, classmap?: list<string>, files?: list<string>} $devAutoload */
+            $rootPackage->setDevAutoload($devAutoload);
+            $this->writeAdoptedNamespaceMessage(
+                $io,
+                $type,
+                $package->getName(),
+                '',
+                $modifiedNamespacePath
+            );
+        }
+    }
+
+    /**
+     * Prefix package source url (relative path) to namespace.
+     */
+    private function modifyPackageNamespacePath(PackageInterface $package, string $namespacePath): string
+    {
+        $filesystem = new Filesystem();
+        return rtrim((string)$package->getSourceUrl(), '/')
+            . '/'
+            . $filesystem->normalizePath($namespacePath);
+    }
+
+    /**
+     * Generic message writer to ensure consistent formatting of different outputs.
+     */
+    private function writeAdoptedNamespaceMessage(
+        IOInterface $io,
+        string $key,
+        string $packageName,
+        string $namespace,
+        string $namespacePath
+    ): void {
+        if ($namespace === '') {
+            $io->write(
+                sprintf(
+                    '>> [%s][%s][] = %s adopted.',
+                    $packageName,
+                    $key,
+                    $namespacePath
+                ),
+                true,
+                IOInterface::VERBOSE
+            );
+            return;
+        }
+        $io->write(
+            sprintf(
+                '>> [%s][%s][%s] = %s adopted.',
+                $packageName,
+                $key,
+                $namespace,
+                $namespacePath
+            ),
+            true,
+            IOInterface::VERBOSE
+        );
+    }
+
+    private function isValidPsrNamespace(string $psr): bool
+    {
+        return $psr === 'psr-0' || $psr === 'psr-4';
+    }
+
+    private function isValidNamespace(string $type): bool
+    {
+        return $type === 'files' || $type === 'classmap';
+    }
+}

--- a/tests/Fixtures/fixture-path-repository-structure/.gitignore
+++ b/tests/Fixtures/fixture-path-repository-structure/.gitignore
@@ -1,0 +1,2 @@
+/vendor
+/composer.lock

--- a/tests/Fixtures/fixture-path-repository-structure/Fixtures/Extensions/extension-one/Classes/Dummy.php
+++ b/tests/Fixtures/fixture-path-repository-structure/Fixtures/Extensions/extension-one/Classes/Dummy.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace Vendor\ExtensionOne;
+
+final class Dummy
+{
+    public function dummy(): string
+    {
+        return __METHOD__;
+    }
+}

--- a/tests/Fixtures/fixture-path-repository-structure/Fixtures/Extensions/extension-one/composer.json
+++ b/tests/Fixtures/fixture-path-repository-structure/Fixtures/Extensions/extension-one/composer.json
@@ -1,0 +1,26 @@
+{
+  "name": "vendor/test-extension-one",
+  "description": "TYPO3 test extension one",
+  "type": "typo3-cms-extension",
+  "license": "GPL-2.0-or-later",
+  "authors": [
+    {
+      "name": "Stefan Bürk",
+      "email": "stefan@buerk.tech",
+      "role": "maintainer"
+    }
+  ],
+  "require": {
+    "php": "^7.4 || ^8.0"
+  },
+  "autoload": {
+    "psr-4": {
+      "Vendor\\ExtensionOne\\": "Classes/"
+    }
+  },
+  "extra": {
+    "typo3/cms": {
+      "extension-key": "extension_one"
+    }
+  }
+}

--- a/tests/Fixtures/fixture-path-repository-structure/Fixtures/Extensions/extension-two/Classes/Dummy.php
+++ b/tests/Fixtures/fixture-path-repository-structure/Fixtures/Extensions/extension-two/Classes/Dummy.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace Vendor\ExtensionTwo;
+
+final class Dummy
+{
+    public function dummy(): string
+    {
+        return __METHOD__;
+    }
+}

--- a/tests/Fixtures/fixture-path-repository-structure/Fixtures/Extensions/extension-two/composer.json
+++ b/tests/Fixtures/fixture-path-repository-structure/Fixtures/Extensions/extension-two/composer.json
@@ -1,0 +1,26 @@
+{
+  "name": "vendor/test-extension-two",
+  "description": "TYPO3 test extension two",
+  "type": "typo3-cms-extension",
+  "license": "GPL-2.0-or-later",
+  "authors": [
+    {
+      "name": "Stefan Bürk",
+      "email": "stefan@buerk.tech",
+      "role": "maintainer"
+    }
+  ],
+  "require": {
+    "php": "^7.4 || ^8.0"
+  },
+  "autoload": {
+    "psr-4": {
+      "Vendor\\ExtensionTwo\\": "Classes/"
+    }
+  },
+  "extra": {
+    "typo3/cms": {
+      "extension-key": "extension_two"
+    }
+  }
+}

--- a/tests/Fixtures/fixture-path-repository-structure/Fixtures/Mixed/extension-three/Classes/Dummy.php
+++ b/tests/Fixtures/fixture-path-repository-structure/Fixtures/Mixed/extension-three/Classes/Dummy.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace Vendor\ExtensionThree;
+
+final class Dummy
+{
+    public function dummy(): string
+    {
+        return __METHOD__;
+    }
+}

--- a/tests/Fixtures/fixture-path-repository-structure/Fixtures/Mixed/extension-three/composer.json
+++ b/tests/Fixtures/fixture-path-repository-structure/Fixtures/Mixed/extension-three/composer.json
@@ -1,0 +1,26 @@
+{
+  "name": "vendor/test-extension-three",
+  "description": "TYPO3 test extension three",
+  "type": "typo3-cms-extension",
+  "license": "GPL-2.0-or-later",
+  "authors": [
+    {
+      "name": "Stefan Bürk",
+      "email": "stefan@buerk.tech",
+      "role": "maintainer"
+    }
+  ],
+  "require": {
+    "php": "^7.4 || ^8.0"
+  },
+  "autoload": {
+    "psr-4": {
+      "Vendor\\ExtensionThree\\": "Classes/"
+    }
+  },
+  "extra": {
+    "typo3/cms": {
+      "extension-key": "extension_three"
+    }
+  }
+}

--- a/tests/Fixtures/fixture-path-repository-structure/Fixtures/Mixed/package-two/composer.json
+++ b/tests/Fixtures/fixture-path-repository-structure/Fixtures/Mixed/package-two/composer.json
@@ -1,0 +1,21 @@
+{
+  "name": "vendor/test-package-two",
+  "description": "Test package two",
+  "type": "library",
+  "license": "GPL-2.0-or-later",
+  "authors": [
+    {
+      "name": "Stefan Bürk",
+      "email": "stefan@buerk.tech",
+      "role": "maintainer"
+    }
+  ],
+  "require": {
+    "php": "^7.4 || ^8.0"
+  },
+  "autoload": {
+    "psr-4": {
+      "Vendor\\PackageTwo\\": "src"
+    }
+  }
+}

--- a/tests/Fixtures/fixture-path-repository-structure/Fixtures/Mixed/package-two/src/Dummy.php
+++ b/tests/Fixtures/fixture-path-repository-structure/Fixtures/Mixed/package-two/src/Dummy.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace Vendor\PackageTwo;
+
+final class Dummy
+{
+    public function dummy(): string
+    {
+        return __METHOD__;
+    }
+}

--- a/tests/Fixtures/fixture-path-repository-structure/Fixtures/Packages/package-one/composer.json
+++ b/tests/Fixtures/fixture-path-repository-structure/Fixtures/Packages/package-one/composer.json
@@ -1,0 +1,21 @@
+{
+  "name": "vendor/test-package-one",
+  "description": "Test package one",
+  "type": "library",
+  "license": "GPL-2.0-or-later",
+  "authors": [
+    {
+      "name": "Stefan Bürk",
+      "email": "stefan@buerk.tech",
+      "role": "maintainer"
+    }
+  ],
+  "require": {
+    "php": "^7.4 || ^8.0"
+  },
+  "autoload": {
+    "psr-4": {
+      "Vendor\\PackageOne\\": "src"
+    }
+  }
+}

--- a/tests/Fixtures/fixture-path-repository-structure/Fixtures/Packages/package-one/src/Dummy.php
+++ b/tests/Fixtures/fixture-path-repository-structure/Fixtures/Packages/package-one/src/Dummy.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace Vendor\PackageOne;
+
+final class Dummy
+{
+    public function dummy(): string
+    {
+        return __METHOD__;
+    }
+}

--- a/tests/Fixtures/fixture-path-repository-structure/Packages/local-one/Fixtures/Extensions/extension-four/Classes/Dummy.php
+++ b/tests/Fixtures/fixture-path-repository-structure/Packages/local-one/Fixtures/Extensions/extension-four/Classes/Dummy.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace Vendor\ExtensionFour;
+
+final class Dummy
+{
+    public function dummy(): string
+    {
+        return __METHOD__;
+    }
+}

--- a/tests/Fixtures/fixture-path-repository-structure/Packages/local-one/Fixtures/Extensions/extension-four/composer.json
+++ b/tests/Fixtures/fixture-path-repository-structure/Packages/local-one/Fixtures/Extensions/extension-four/composer.json
@@ -1,0 +1,26 @@
+{
+  "name": "vendor/test-extension-four",
+  "description": "TYPO3 test extension four",
+  "type": "typo3-cms-extension",
+  "license": "GPL-2.0-or-later",
+  "authors": [
+    {
+      "name": "Stefan Bürk",
+      "email": "stefan@buerk.tech",
+      "role": "maintainer"
+    }
+  ],
+  "require": {
+    "php": "^7.4 || ^8.0"
+  },
+  "autoload": {
+    "psr-4": {
+      "Vendor\\ExtensionFour\\": "Classes/"
+    }
+  },
+  "extra": {
+    "typo3/cms": {
+      "extension-key": "extension_four"
+    }
+  }
+}

--- a/tests/Fixtures/fixture-path-repository-structure/Packages/local-two/Fixtures/Extensions/extension-five/Classes/Dummy.php
+++ b/tests/Fixtures/fixture-path-repository-structure/Packages/local-two/Fixtures/Extensions/extension-five/Classes/Dummy.php
@@ -15,18 +15,12 @@ declare(strict_types=1);
  * The TYPO3 project - inspiring people to share!
  */
 
-namespace SBUERK\TestFixtureExtensionAdopter\Tests\Unit;
+namespace Vendor\ExtensionFive;
 
-use PHPUnit\Framework\TestCase;
-use SBUERK\TestFixtureExtensionAdopter\Dummy;
-
-final class DummyTest extends TestCase
+final class Dummy
 {
-    /**
-     * @test
-     */
-    public function dummyInstanceCanBeCreatedUsingNewKeyWord(): void
+    public function dummy(): string
     {
-        self::assertIsObject(new Dummy());
+        return __METHOD__;
     }
 }

--- a/tests/Fixtures/fixture-path-repository-structure/Packages/local-two/Fixtures/Extensions/extension-five/composer.json
+++ b/tests/Fixtures/fixture-path-repository-structure/Packages/local-two/Fixtures/Extensions/extension-five/composer.json
@@ -1,0 +1,26 @@
+{
+  "name": "vendor/test-extension-five",
+  "description": "TYPO3 test extension five",
+  "type": "typo3-cms-extension",
+  "license": "GPL-2.0-or-later",
+  "authors": [
+    {
+      "name": "Stefan Bürk",
+      "email": "stefan@buerk.tech",
+      "role": "maintainer"
+    }
+  ],
+  "require": {
+    "php": "^7.4 || ^8.0"
+  },
+  "autoload": {
+    "psr-4": {
+      "Vendor\\ExtensionFive\\": "Classes/"
+    }
+  },
+  "extra": {
+    "typo3/cms": {
+      "extension-key": "extension_five"
+    }
+  }
+}

--- a/tests/Fixtures/fixture-path-repository-structure/composer.json
+++ b/tests/Fixtures/fixture-path-repository-structure/composer.json
@@ -1,0 +1,43 @@
+{
+  "name": "vendor/project-fixture-path-repository",
+  "description": "test project",
+  "type": "project",
+  "license": "GPL-2.0-or-later",
+  "authors": [
+    {
+      "name": "Stefan Bürk",
+      "email": "stefan@buerk.tech",
+      "role": "maintainer"
+    }
+  ],
+  "config": {
+    "allow-plugins": {
+      "sbuerk/fixture-packages": true
+    }
+  },
+  "repositories": {
+    "plugin": {
+      "type": "path",
+      "url": "../../../"
+    }
+  },
+  "require": {
+    "php": "^7.4 || ^8.0",
+    "sbuerk/fixture-packages": "@dev"
+  },
+  "autoload": {
+    "psr-4": {
+      "Vendor\\ProjectOne\\": "Classes/"
+    }
+  },
+  "extra": {
+    "sbuerk/fixture-packages": {
+      "paths": [
+        "Fixtures/Extensions/*",
+        "Fixtures/Mixed/*",
+        "Fixtures/Packages/package-one",
+        "Packages/*/Fixtures/Extensions/*"
+      ]
+    }
+  }
+}

--- a/tests/Fixtures/plugin-only/composer.json
+++ b/tests/Fixtures/plugin-only/composer.json
@@ -1,0 +1,28 @@
+{
+  "name": "vendor/plugin-only",
+  "description": "test project",
+  "type": "project",
+  "license": "GPL-2.0-or-later",
+  "authors": [
+    {
+      "name": "Stefan Bürk",
+      "email": "stefan@buerk.tech",
+      "role": "maintainer"
+    }
+  ],
+  "config": {
+    "allow-plugins": {
+      "sbuerk/typo3-test-fixture-extension-adopter": true
+    }
+  },
+  "repositories": {
+    "plugin": {
+      "type": "path",
+      "url": "../../../"
+    }
+  },
+  "require": {
+    "php": "^7.4 || ^8.0",
+    "sbuerk/typo3-test-fixture-extension-adopter": "@dev"
+  }
+}

--- a/tests/Fixtures/project-one/composer.json
+++ b/tests/Fixtures/project-one/composer.json
@@ -1,0 +1,28 @@
+{
+  "name": "vendor/project-one",
+  "description": "TYPO3 test extension one",
+  "type": "project",
+  "license": "GPL-2.0-or-later",
+  "authors": [
+    {
+      "name": "Stefan Bürk",
+      "email": "stefan@buerk.tech",
+      "role": "maintainer"
+    }
+  ],
+  "require": {
+    "php": "^7.4 || ^8.0"
+  },
+  "autoload": {
+    "psr-4": {
+      "Vendor\\ProjectOne": "Classes/"
+    }
+  },
+  "extra": {
+    "sbuerk/fixture-packages": {
+      "paths": [
+        "tests/Fixtures/Extensions/*"
+      ]
+    }
+  }
+}

--- a/tests/Fixtures/project-one/src/Dummy.php
+++ b/tests/Fixtures/project-one/src/Dummy.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace Vendor\ProjectOne;
+
+final class Dummy
+{
+    public function dummy(): string
+    {
+        return implode(
+            "\n",
+            [
+                'EXTENSION_ONE_DUMMY_CLASS: ' . (class_exists(\Vendor\ExtensionOne\Dummy::class) ? \Vendor\ExtensionOne\Dummy::class : 'missing'),
+            ]
+        );
+    }
+}

--- a/tests/Fixtures/project-one/tests/Fixtures/Extensions/extension-one/Classes/Dummy.php
+++ b/tests/Fixtures/project-one/tests/Fixtures/Extensions/extension-one/Classes/Dummy.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace Vendor\ExtensionOne;
+
+final class Dummy
+{
+    public function dummy(): string
+    {
+        return __METHOD__;
+    }
+}

--- a/tests/Fixtures/project-one/tests/Fixtures/Extensions/extension-one/composer.json
+++ b/tests/Fixtures/project-one/tests/Fixtures/Extensions/extension-one/composer.json
@@ -1,0 +1,26 @@
+{
+  "name": "vendor/test-extension-one",
+  "description": "TYPO3 test extension one",
+  "type": "typo3-cms-extension",
+  "license": "GPL-2.0-or-later",
+  "authors": [
+    {
+      "name": "Stefan Bürk",
+      "email": "stefan@buerk.tech",
+      "role": "maintainer"
+    }
+  ],
+  "require": {
+    "php": "^7.4 || ^8.0"
+  },
+  "autoload": {
+    "psr-4": {
+      "Vendor\\ExtensionOne": "Classes/"
+    }
+  },
+  "extra": {
+    "typo3/cms": {
+      "extension-key": "extension_one"
+    }
+  }
+}

--- a/tests/Integration/Fixtures/Instances/integration/Fixtures/Extensions/extension-one/Classes/Dummy.php
+++ b/tests/Integration/Fixtures/Instances/integration/Fixtures/Extensions/extension-one/Classes/Dummy.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace Vendor\ExtensionOne;
+
+final class Dummy
+{
+    public function dummy(): string
+    {
+        return __METHOD__;
+    }
+}

--- a/tests/Integration/Fixtures/Instances/integration/Fixtures/Extensions/extension-one/composer.json
+++ b/tests/Integration/Fixtures/Instances/integration/Fixtures/Extensions/extension-one/composer.json
@@ -1,0 +1,26 @@
+{
+  "name": "vendor/test-extension-one",
+  "description": "TYPO3 test extension one",
+  "type": "typo3-cms-extension",
+  "license": "GPL-2.0-or-later",
+  "authors": [
+    {
+      "name": "Stefan Bürk",
+      "email": "stefan@buerk.tech",
+      "role": "maintainer"
+    }
+  ],
+  "require": {
+    "php": "^7.4 || ^8.0"
+  },
+  "autoload": {
+    "psr-4": {
+      "Vendor\\ExtensionOne\\": "Classes/"
+    }
+  },
+  "extra": {
+    "typo3/cms": {
+      "extension-key": "extension_one"
+    }
+  }
+}

--- a/tests/Integration/Fixtures/Instances/integration/Fixtures/Extensions/extension-two/Classes/Dummy.php
+++ b/tests/Integration/Fixtures/Instances/integration/Fixtures/Extensions/extension-two/Classes/Dummy.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace Vendor\ExtensionTwo;
+
+final class Dummy
+{
+    public function dummy(): string
+    {
+        return __METHOD__;
+    }
+}

--- a/tests/Integration/Fixtures/Instances/integration/Fixtures/Extensions/extension-two/composer.json
+++ b/tests/Integration/Fixtures/Instances/integration/Fixtures/Extensions/extension-two/composer.json
@@ -1,0 +1,26 @@
+{
+  "name": "vendor/test-extension-two",
+  "description": "TYPO3 test extension two",
+  "type": "typo3-cms-extension",
+  "license": "GPL-2.0-or-later",
+  "authors": [
+    {
+      "name": "Stefan Bürk",
+      "email": "stefan@buerk.tech",
+      "role": "maintainer"
+    }
+  ],
+  "require": {
+    "php": "^7.4 || ^8.0"
+  },
+  "autoload": {
+    "psr-4": {
+      "Vendor\\ExtensionTwo\\": "Classes/"
+    }
+  },
+  "extra": {
+    "typo3/cms": {
+      "extension-key": "extension_two"
+    }
+  }
+}

--- a/tests/Integration/Fixtures/Instances/integration/Fixtures/Mixed/extension-three/Classes/Dummy.php
+++ b/tests/Integration/Fixtures/Instances/integration/Fixtures/Mixed/extension-three/Classes/Dummy.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace Vendor\ExtensionThree;
+
+final class Dummy
+{
+    public function dummy(): string
+    {
+        return __METHOD__;
+    }
+}

--- a/tests/Integration/Fixtures/Instances/integration/Fixtures/Mixed/extension-three/composer.json
+++ b/tests/Integration/Fixtures/Instances/integration/Fixtures/Mixed/extension-three/composer.json
@@ -1,0 +1,26 @@
+{
+  "name": "vendor/test-extension-three",
+  "description": "TYPO3 test extension three",
+  "type": "typo3-cms-extension",
+  "license": "GPL-2.0-or-later",
+  "authors": [
+    {
+      "name": "Stefan Bürk",
+      "email": "stefan@buerk.tech",
+      "role": "maintainer"
+    }
+  ],
+  "require": {
+    "php": "^7.4 || ^8.0"
+  },
+  "autoload": {
+    "psr-4": {
+      "Vendor\\ExtensionThree\\": "Classes/"
+    }
+  },
+  "extra": {
+    "typo3/cms": {
+      "extension-key": "extension_three"
+    }
+  }
+}

--- a/tests/Integration/Fixtures/Instances/integration/Fixtures/Mixed/package-two/composer.json
+++ b/tests/Integration/Fixtures/Instances/integration/Fixtures/Mixed/package-two/composer.json
@@ -1,0 +1,21 @@
+{
+  "name": "vendor/test-package-two",
+  "description": "Test package two",
+  "type": "library",
+  "license": "GPL-2.0-or-later",
+  "authors": [
+    {
+      "name": "Stefan Bürk",
+      "email": "stefan@buerk.tech",
+      "role": "maintainer"
+    }
+  ],
+  "require": {
+    "php": "^7.4 || ^8.0"
+  },
+  "autoload": {
+    "psr-4": {
+      "Vendor\\PackageTwo\\": "src"
+    }
+  }
+}

--- a/tests/Integration/Fixtures/Instances/integration/Fixtures/Mixed/package-two/src/Dummy.php
+++ b/tests/Integration/Fixtures/Instances/integration/Fixtures/Mixed/package-two/src/Dummy.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace Vendor\PackageTwo;
+
+final class Dummy
+{
+    public function dummy(): string
+    {
+        return __METHOD__;
+    }
+}

--- a/tests/Integration/Fixtures/Instances/integration/Fixtures/Packages/package-one/composer.json
+++ b/tests/Integration/Fixtures/Instances/integration/Fixtures/Packages/package-one/composer.json
@@ -1,0 +1,21 @@
+{
+  "name": "vendor/test-package-one",
+  "description": "Test package one",
+  "type": "library",
+  "license": "GPL-2.0-or-later",
+  "authors": [
+    {
+      "name": "Stefan Bürk",
+      "email": "stefan@buerk.tech",
+      "role": "maintainer"
+    }
+  ],
+  "require": {
+    "php": "^7.4 || ^8.0"
+  },
+  "autoload": {
+    "psr-4": {
+      "Vendor\\PackageOne\\": "src"
+    }
+  }
+}

--- a/tests/Integration/Fixtures/Instances/integration/Fixtures/Packages/package-one/src/Dummy.php
+++ b/tests/Integration/Fixtures/Instances/integration/Fixtures/Packages/package-one/src/Dummy.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace Vendor\PackageOne;
+
+final class Dummy
+{
+    public function dummy(): string
+    {
+        return __METHOD__;
+    }
+}

--- a/tests/Integration/Fixtures/Instances/integration/Packages/local-one/Fixtures/Extensions/extension-four/Classes/Dummy.php
+++ b/tests/Integration/Fixtures/Instances/integration/Packages/local-one/Fixtures/Extensions/extension-four/Classes/Dummy.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace Vendor\ExtensionFour;
+
+final class Dummy
+{
+    public function dummy(): string
+    {
+        return __METHOD__;
+    }
+}

--- a/tests/Integration/Fixtures/Instances/integration/Packages/local-one/Fixtures/Extensions/extension-four/composer.json
+++ b/tests/Integration/Fixtures/Instances/integration/Packages/local-one/Fixtures/Extensions/extension-four/composer.json
@@ -1,0 +1,26 @@
+{
+  "name": "vendor/test-extension-four",
+  "description": "TYPO3 test extension four",
+  "type": "typo3-cms-extension",
+  "license": "GPL-2.0-or-later",
+  "authors": [
+    {
+      "name": "Stefan Bürk",
+      "email": "stefan@buerk.tech",
+      "role": "maintainer"
+    }
+  ],
+  "require": {
+    "php": "^7.4 || ^8.0"
+  },
+  "autoload": {
+    "psr-4": {
+      "Vendor\\ExtensionFour\\": "Classes/"
+    }
+  },
+  "extra": {
+    "typo3/cms": {
+      "extension-key": "extension_four"
+    }
+  }
+}

--- a/tests/Integration/Fixtures/Instances/integration/Packages/local-two/Fixtures/Extensions/extension-five/Classes/Dummy.php
+++ b/tests/Integration/Fixtures/Instances/integration/Packages/local-two/Fixtures/Extensions/extension-five/Classes/Dummy.php
@@ -15,6 +15,12 @@ declare(strict_types=1);
  * The TYPO3 project - inspiring people to share!
  */
 
-namespace SBUERK\TestFixtureExtensionAdopter;
+namespace Vendor\ExtensionFive;
 
-final class Dummy {}
+final class Dummy
+{
+    public function dummy(): string
+    {
+        return __METHOD__;
+    }
+}

--- a/tests/Integration/Fixtures/Instances/integration/Packages/local-two/Fixtures/Extensions/extension-five/composer.json
+++ b/tests/Integration/Fixtures/Instances/integration/Packages/local-two/Fixtures/Extensions/extension-five/composer.json
@@ -1,0 +1,26 @@
+{
+  "name": "vendor/test-extension-five",
+  "description": "TYPO3 test extension five",
+  "type": "typo3-cms-extension",
+  "license": "GPL-2.0-or-later",
+  "authors": [
+    {
+      "name": "Stefan Bürk",
+      "email": "stefan@buerk.tech",
+      "role": "maintainer"
+    }
+  ],
+  "require": {
+    "php": "^7.4 || ^8.0"
+  },
+  "autoload": {
+    "psr-4": {
+      "Vendor\\ExtensionFive\\": "Classes/"
+    }
+  },
+  "extra": {
+    "typo3/cms": {
+      "extension-key": "extension_five"
+    }
+  }
+}

--- a/tests/Integration/Fixtures/Instances/integration/composer.json
+++ b/tests/Integration/Fixtures/Instances/integration/composer.json
@@ -1,0 +1,43 @@
+{
+  "name": "vendor/project-fixture-path-repository",
+  "description": "test project",
+  "type": "project",
+  "license": "GPL-2.0-or-later",
+  "authors": [
+    {
+      "name": "Stefan Bürk",
+      "email": "stefan@buerk.tech",
+      "role": "maintainer"
+    }
+  ],
+  "config": {
+    "allow-plugins": {
+      "sbuerk/fixture-packages": true
+    }
+  },
+  "repositories": {
+    "plugin": {
+      "type": "path",
+      "url": "../../../"
+    }
+  },
+  "require-dev": {
+    "php": "^7.4 || ^8.0",
+    "sbuerk/fixture-packages": "@dev"
+  },
+  "autoload": {
+    "psr-4": {
+      "Vendor\\ProjectOne\\": "Classes/"
+    }
+  },
+  "extra": {
+    "sbuerk/fixture-packages": {
+      "paths": [
+        "Fixtures/Extensions/*",
+        "Fixtures/Mixed/*",
+        "Fixtures/Packages/package-one",
+        "Packages/*/Fixtures/Extensions/*"
+      ]
+    }
+  }
+}

--- a/tests/Integration/IntegrationTest.php
+++ b/tests/Integration/IntegrationTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace SBUERK\FixturePackages\Tests\Integration;
+
+use Composer\IO\BufferIO;
+use Composer\IO\IOInterface;
+use Symfony\Component\Console\Output\StreamOutput;
+
+final class IntegrationTest extends IntegrationTestCase
+{
+    private ?IOInterface $io = null;
+
+    private bool $created = false;
+    protected function setUp(): void
+    {
+        $this->io = new BufferIO('', StreamOutput::VERBOSITY_DEBUG);
+        parent::setUp();
+        if (!$this->created) {
+            $this->copyInstanceTemplate('integration');
+            $this->composerInstall($this->testInstancePath(), $this->io);
+            $this->created = true;
+        } else {
+            if (!is_dir($this->testInstancePath())) {
+                self::fail('Test instance does not exists from first setup.');
+            }
+            chdir($this->testInstancePath());
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function exportFileExists(): void
+    {
+        self::assertFileExists($this->testInstancePath() . '/vendor/sbuerk/fixture-packages.php');
+    }
+
+    /**
+     * @depends exportFileExists
+     * @test
+     */
+    public function exportFileReturnsExpectedExport(): void
+    {
+        $expectedRelativePath = $this->testInstancePath() . '/vendor/sbuerk/../..';
+        $expected = [
+            'vendor/test-extension-one' => [
+                'name' => 'vendor/test-extension-one',
+                'type' => 'typo3-cms-extension',
+                'path' => $expectedRelativePath . '/Fixtures/Extensions/extension-one',
+                'extra' => [
+                    'typo3/cms' => [
+                        'extension-key' => 'extension_one',
+                    ],
+                ],
+            ],
+            'vendor/test-extension-two' => [
+                'name' => 'vendor/test-extension-two',
+                'type' => 'typo3-cms-extension',
+                'path' => $expectedRelativePath . '/Fixtures/Extensions/extension-two',
+                'extra' => [
+                    'typo3/cms' => [
+                        'extension-key' => 'extension_two',
+                    ],
+                ],
+            ],
+            'vendor/test-extension-three' => [
+                'name' => 'vendor/test-extension-three',
+                'type' => 'typo3-cms-extension',
+                'path' => $expectedRelativePath . '/Fixtures/Mixed/extension-three',
+                'extra' => [
+                    'typo3/cms' => [
+                        'extension-key' => 'extension_three',
+                    ],
+                ],
+            ],
+            'vendor/test-package-two' => [
+                'name' => 'vendor/test-package-two',
+                'type' => 'library',
+                'path' => $expectedRelativePath . '/Fixtures/Mixed/package-two',
+                'extra' => [],
+            ],
+            'vendor/test-package-one' => [
+                'name' => 'vendor/test-package-one',
+                'type' => 'library',
+                'path' => $expectedRelativePath . '/Fixtures/Packages/package-one',
+                'extra' => [],
+            ],
+            'vendor/test-extension-four' => [
+                'name' => 'vendor/test-extension-four',
+                'type' => 'typo3-cms-extension',
+                'path' => $expectedRelativePath . '/Packages/local-one/Fixtures/Extensions/extension-four',
+                'extra' => [
+                    'typo3/cms' => [
+                        'extension-key' => 'extension_four',
+                    ],
+                ],
+            ],
+            'vendor/test-extension-five' => [
+                'name' => 'vendor/test-extension-five',
+                'type' => 'typo3-cms-extension',
+                'path' => $expectedRelativePath . '/Packages/local-two/Fixtures/Extensions/extension-five',
+                'extra' => [
+                    'typo3/cms' => [
+                        'extension-key' => 'extension_five',
+                    ],
+                ],
+            ],
+        ];
+        self::assertSame($expected, include $this->testInstancePath() . '/vendor/sbuerk/fixture-packages.php');
+    }
+}

--- a/tests/Integration/IntegrationTestCase.php
+++ b/tests/Integration/IntegrationTestCase.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace SBUERK\FixturePackages\Tests\Integration;
+
+use Composer\Advisory\Auditor;
+use Composer\Factory;
+use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilterFactory;
+use Composer\Installer;
+use Composer\IO\IOInterface;
+use Composer\IO\NullIO;
+use Composer\Util\Filesystem;
+use PHPUnit\Framework\TestCase;
+use SBUERK\FixturePackages\Plugin\Config;
+
+abstract class IntegrationTestCase extends TestCase
+{
+    protected Filesystem $composerFileSystem;
+    private string $oldWorkingDirectory = '';
+
+    private string $baseTestInstanceDirectory = __DIR__ . '/../../.cache/instances';
+
+    private string $instanceTemplatePath = __DIR__ . '/Fixtures/Instances';
+
+    protected function setUp(): void
+    {
+        $this->composerFileSystem = new Filesystem();
+        $this->composerFileSystem->ensureDirectoryExists($this->baseTestInstancePath());
+
+        // Backup current working folder, so it can be restored in self::tearDown(). Some tests requires to change
+        // the working directory, but we should restore original working directory to avoid a dirty environment.
+        $this->oldWorkingDirectory = getcwd();
+
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        // Restore original working directory. Required for a couple of tests, which requires to operate
+        // in fixture folders, but we want to be in starting folder afterward to avoid a dirty environment.
+        chdir($this->oldWorkingDirectory);
+
+        /**
+         * Reset static property {@see Config::$instance} holding instance used within {@see Config::load()}. This
+         * essential, otherwise tests will fail for different scenarios.
+         */
+        (new \ReflectionClass(Config::class))->setStaticPropertyValue('instance', null);
+
+        parent::tearDown();
+    }
+
+    protected function copyInstanceTemplate(string $template, ?string $identifier = null): void
+    {
+        $identifier = $identifier ?: $this->identifier();
+        $template = ltrim($this->composerFileSystem->normalizePath($template), '/');
+        $identifier = ltrim($this->composerFileSystem->normalizePath($identifier), '/');
+        $fullTemplatePath = $this->instanceTemplatePath() . '/' . $template;
+        $fullTestInstancePath = $this->testInstancePath($identifier);
+        if (!is_dir($fullTemplatePath)) {
+            self::fail(sprintf('Template path "%s" does not exists, could not copy as test instance "%s".', $fullTemplatePath, $identifier));
+        }
+        $this->composerFileSystem->emptyDirectory($fullTestInstancePath);
+        if (!$this->composerFileSystem->copy($fullTemplatePath, $fullTestInstancePath)) {
+            self::fail(sprintf('Failed to copy template path "%s" to "%s".', $fullTemplatePath, $fullTestInstancePath));
+        }
+    }
+
+    protected function testInstancePath(?string $identifier = null): string
+    {
+        return $this->baseTestInstancePath() . '/' . ($identifier ?: $this->identifier());
+    }
+
+    protected function instanceTemplatePath(): string
+    {
+        return $this->composerFileSystem->normalizePath($this->instanceTemplatePath);
+    }
+
+    protected function baseTestInstancePath(): string
+    {
+        return $this->composerFileSystem->normalizePath($this->baseTestInstanceDirectory);
+    }
+
+    protected function identifier(): string
+    {
+        return hash('sha256', \json_encode([
+            'classFQN' => static::class,
+            'name' => $this->getName(),
+        ]));
+    }
+
+    protected function composerInstall(string $baseDir, ?IOInterface $io): int
+    {
+        chdir($baseDir);
+        $io ??= new NullIO();
+        $composerConfig = Factory::createConfig($io, $baseDir);
+        $composer = Factory::create($io);
+        $install = Installer::create($io, $composer);
+        $composer->getInstallationManager()->setOutputProgress(false);
+        $install
+            ->setDryRun(false)
+            ->setDownloadOnly(false)
+            ->setVerbose(true)
+            ->setPreferSource(true)
+            ->setPreferDist(false)
+            ->setDevMode(true)
+            ->setDumpAutoloader(true)
+            ->setOptimizeAutoloader(false)
+            ->setClassMapAuthoritative(false)
+            ->setApcuAutoloader(false, null)
+            ->setPlatformRequirementFilter(PlatformRequirementFilterFactory::ignoreNothing())
+            ->setAudit(false)
+            ->setErrorOnAudit(false)
+            ->setAuditFormat(Auditor::FORMAT_TABLE)
+        ;
+        return $install->run();
+    }
+}

--- a/tests/Unit/BaseUnitTestCase.php
+++ b/tests/Unit/BaseUnitTestCase.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace SBUERK\FixturePackages\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use SBUERK\FixturePackages\Plugin\Config;
+
+abstract class BaseUnitTestCase extends TestCase
+{
+    private string $oldWorkingDirectory = '';
+
+    public function setUp(): void
+    {
+        // Backup current working folder, so it can be restored in self::tearDown(). Some tests requires to change
+        // the working directory, but we should restore original working directory to avoid a dirty environment.
+        $this->oldWorkingDirectory = getcwd();
+
+        parent::setUp();
+    }
+
+    public function tearDown(): void
+    {
+        // Restore original working directory. Required for a couple of tests, which requires to operate
+        // in fixture folders, but we want to be in starting folder afterward to avoid a dirty environment.
+        chdir($this->oldWorkingDirectory);
+
+        /**
+         * Reset static property {@see Config::$instance} holding instance used within {@see Config::load()}. This
+         * essential, otherwise tests will fail for different scenarios.
+         */
+        (new \ReflectionClass(Config::class))->setStaticPropertyValue('instance', null);
+
+        parent::tearDown();
+    }
+
+    /**
+     * @param object|string $object
+     * @param string $method
+     * @return \ReflectionMethod
+     * @throws \ReflectionException
+     */
+    protected function createClassMethodInvoker($object, string $method): \ReflectionMethod
+    {
+        if (!((is_string($object) && class_exists($object)) || is_object($object))) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Argument $object must be of type `object|string`, provided: %s',
+                    gettype($object)
+                ),
+                1738868978
+            );
+        }
+        if ($object instanceof \ReflectionClass) {
+            $invoker = $object->getMethod($method);
+        } else {
+            $invoker = new \ReflectionMethod($object, $method);
+        }
+        if (PHP_VERSION_ID < 801000) {
+            $invoker->setAccessible(true);
+        }
+        return $invoker;
+    }
+
+    /**
+     * @throws \ReflectionException
+     */
+    protected function createClassReflection($object): \ReflectionClass
+    {
+        if (!((is_string($object) && class_exists($object)) || is_object($object))) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Argument $object must be of type `object|string`, provided: %s',
+                    gettype($object)
+                ),
+                1738868978
+            );
+        }
+        return new \ReflectionClass($object);
+    }
+}

--- a/tests/Unit/DummyTest.php
+++ b/tests/Unit/DummyTest.php
@@ -2,6 +2,19 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
 namespace SBUERK\TestFixtureExtensionAdopter\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Plugin/ConfigTest.php
+++ b/tests/Unit/Plugin/ConfigTest.php
@@ -1,0 +1,361 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SBUERK\TestFixtureExtensionAdopter\Tests\Unit\Plugin;
+
+use Composer\Composer;
+use Composer\IO\BufferIO;
+use Composer\Package\RootPackage;
+use PHPUnit\Framework\TestCase;
+use SBUERK\TestFixtureExtensionAdopter\Plugin\Config;
+
+final class ConfigTest extends TestCase
+{
+
+    public function tearDown(): void
+    {
+        /**
+         * Reset static property {@see Config::$instance} holding instance used within {@see Config::load()}. This
+         * essential, otherwise tests will fail for different scenarios.
+         */
+        $this->createSubjectClassReflection()->setStaticPropertyValue('instance', null);
+        parent::tearDown();
+    }
+
+    private function createSubject(string $baseDir = '/fake/root'): Config
+    {
+        return new Config($baseDir);
+    }
+
+    private function createSubjectMethodReflection(string $method): \ReflectionMethod
+    {
+        $methodReflection = $this->createSubjectClassReflection()->getMethod($method);
+        if (PHP_VERSION_ID < 801000) {
+            $methodReflection->setAccessible(true);
+        }
+        $methodReflection->setAccessible(true);
+        return $methodReflection;
+    }
+
+    private function createSubjectClassReflection(): \ReflectionClass
+    {
+        return new \ReflectionClass(Config::class);
+    }
+
+    public static function normalizePathDataSets(): \Generator
+    {
+        yield 'Empty string returns empty string' => [
+            'value' => '',
+            'expectedValue' => '',
+        ];
+        yield 'Single slash is returned as single slash' => [
+            'value' => '/',
+            'expectedValue' => '/',
+        ];
+        yield 'Drive letter is kept' => [
+            'value' => 'C:/',
+            'expectedValue' => 'C:/',
+        ];
+        yield 'Windows path backslash is normalized to slash keeping drive letter' => [
+            'value' => 'C:\\',
+            'expectedValue' => 'C:/',
+        ];
+        yield 'Unix path are trimmed' => [
+            'value' => '/some/path/',
+            'expectedValue' => '/some/path',
+        ];
+        yield 'Unix path ending in backslash is trimmed' => [
+            'value' => '/some/path\\',
+            'expectedValue' => '/some/path',
+        ];
+        yield 'Windows path are trimmed keeping drive letter' => [
+            'value' => 'C:/some/path/',
+            'expectedValue' => 'C:/some/path',
+        ];
+        yield 'Windows path ending in backslash are trimmed keeping drive letter' => [
+            'value' => 'C:/some/path\\',
+            'expectedValue' => 'C:/some/path',
+        ];
+    }
+
+    public function normalizePathReturnsExpectedValue(string $value, string $expectedValue): void
+    {
+        $realpathMethodInvoker = $this->createSubjectMethodReflection('normalizePath');
+        self::assertSame($expectedValue, $realpathMethodInvoker->invoke($this->createSubject(), $value));
+    }
+
+    public static function realpathDataSets(): \Generator
+    {
+        yield 'Empty path returns baseDir' => [
+            'baseDir' => '/fake/root',
+            'path' => '',
+            'expectedPath' => '/fake/root',
+        ];
+        yield 'Valid absolute path is returned directly' => [
+            'baseDir' => '/fake/root',
+            'path' => '/some/absolute/path',
+            'expectedPath' => '/some/absolute/path',
+        ];
+        yield 'Valid absolute path is returned trimmed' => [
+            'baseDir' => '/fake/root',
+            'path' => '/some/absolute/path/',
+            'expectedPath' => '/some/absolute/path',
+        ];
+        yield 'Mixed slash and backslash absolute path is returned normalized to slashes' => [
+            'baseDir' => '/fake/root',
+            'path' => '/some\absolute/path/',
+            'expectedPath' => '/some/absolute/path',
+        ];
+        yield 'Valid normalized absolute windows path is returned directly keeping drive letter' => [
+            'baseDir' => '/fake/root',
+            'path' => 'C:/some/absolute/path',
+            'expectedPath' => 'C:/some/absolute/path',
+        ];
+        yield 'Valid absolute windows path is returned normalized keeping drive letter' => [
+            'baseDir' => '/fake/root',
+            'path' => 'C:\some\absolute\path',
+            'expectedPath' => 'C:/some/absolute/path',
+        ];
+        yield 'Valid absolute windows path is returned trimmed keeping drive letter' => [
+            'baseDir' => '/fake/root',
+            'path' => 'C:\some\absolute\path\\',
+            'expectedPath' => 'C:/some/absolute/path',
+        ];
+        yield 'Single slash is returned as single slash' => [
+            'baseDir' => '/fake/root',
+            'path' => '/',
+            'expectedPath' => '/',
+        ];
+    }
+
+    /**
+     * @dataProvider realpathDataSets
+     * @test
+     */
+    public function realpathReturnsExpectedValue(string $baseDir, string $path, string $expectedPath): void
+    {
+        $realpathMethodInvoker = $this->createSubjectMethodReflection('realpath');
+        self::assertSame($expectedPath, $realpathMethodInvoker->invoke($this->createSubject($baseDir), $path));
+    }
+
+    public static function handleRootPackageExtraConfigReturnsExpectedConfigArrayDataSets(): \Generator
+    {
+        yield 'Empty extra config returns empty array' => [
+            'extraConfig' => [],
+            'expectedConfigArray' => [],
+            'expectedOutput' => '',
+        ];
+        yield 'Other extra configuration are kept' => [
+            'extraConfig' => [
+                'typo3/cms' => [
+                    'extension-key' => 'some_extension_key',
+                ],
+            ],
+            'expectedConfigArray' => [
+                'typo3/cms' => [
+                    'extension-key' => 'some_extension_key',
+                ],
+            ],
+            'expectedOutput' => '',
+        ];
+        yield 'Non-array extra->typo3/testing-framework/fixture-extension-paths value is removed' => [
+            'extraConfig' => [
+                'typo3/testing-framework' => [
+                    'fixture-extension-paths' => false,
+                ],
+            ],
+            'expectedConfigArray' => [
+                'typo3/testing-framework' => [],
+            ],
+            'expectedOutput' => '<warning>extra->typo3/testing-framework/fixture-extension-paths must be an array, "boolean" given.</warning>' . PHP_EOL,
+        ];
+        yield 'Non-array extra->typo3/testing-framework/fixture-extension-paths value is removed keeping other settings' => [
+            'extraConfig' => [
+                'typo3/testing-framework' => [
+                    'other-configuration' => true,
+                    'fixture-extension-paths' => false,
+                ],
+            ],
+            'expectedConfigArray' => [
+                'typo3/testing-framework' => [
+                    'other-configuration' => true,
+                ],
+            ],
+            'expectedOutput' => '<warning>extra->typo3/testing-framework/fixture-extension-paths must be an array, "boolean" given.</warning>' . PHP_EOL,
+        ];
+        yield 'non-relative fixture extension paths are discarded and outputs warning' => [
+            'extraConfig' => [
+                'typo3/testing-framework' => [
+                    'fixture-extension-paths' => [
+                        '/absolute/path',
+                    ],
+                ],
+            ],
+            'expectedConfigArray' => [
+                'typo3/testing-framework' => [
+                    'fixture-extension-paths' => [],
+                ],
+            ],
+            'expectedOutput' => sprintf(
+                '<warning>Test fixture extension path must be a subdirectory of Composer root directory. Skip "%s".</warning>' . PHP_EOL,
+                '/absolute/path'
+            ),
+        ];
+        yield 'non-relative fixture exetension paths are discarded and outputs warning, but keeps relative paths' => [
+            'extraConfig' => [
+                'typo3/testing-framework' => [
+                    'fixture-extension-paths' => [
+                        '/absolute/path',
+                        'relative/path',
+                    ],
+                ],
+            ],
+            'expectedConfigArray' => [
+                'typo3/testing-framework' => [
+                    'fixture-extension-paths' => [
+                        'relative/path',
+                    ],
+                ],
+            ],
+            'expectedOutput' => sprintf(
+                '<warning>Test fixture extension path must be a subdirectory of Composer root directory. Skip "%s".</warning>' . PHP_EOL,
+                '/absolute/path'
+            ),
+        ];
+        yield 'relative path leaving composer root is discarded and outputs warning' => [
+            'extraConfig' => [
+                'typo3/testing-framework' => [
+                    'fixture-extension-paths' => [
+                        'relative/../../path-outside-composer-root',
+                    ],
+                ],
+            ],
+            'expectedConfigArray' => [
+                'typo3/testing-framework' => [
+                    'fixture-extension-paths' => [],
+                ],
+            ],
+            'expectedOutput' => sprintf(
+                '<warning>Test fixture extension path must be a subdirectory of Composer root directory. Skip "%s".</warning>' . PHP_EOL,
+                'relative/../../path-outside-composer-root'
+            ),
+        ];
+    }
+
+    /**
+     * @dataProvider handleRootPackageExtraConfigReturnsExpectedConfigArrayDataSets
+     * @test
+     */
+    public function handleRootPackageExtraConfigReturnsExpectedConfigArray(array $extraConfig, array $expectedConfigArray, string $expectedOutput): void
+    {
+        $rootPackage = new RootPackage('fake/package', '1.0.0', '1.0.0.0');
+        $rootPackage->setExtra($extraConfig);
+        $methodReflection =  $this->createSubjectMethodReflection('handleRootPackageExtraConfig');
+        $bufferedIO = new BufferIO();
+        self::assertSame($expectedConfigArray, $methodReflection->invoke($this->createSubject(), $bufferedIO, $rootPackage));
+        self::assertSame($expectedOutput, $bufferedIO->getOutput());
+    }
+
+
+    public static function loadCreatesConfigWithExpectedPathsDataSets(): \Generator
+    {
+        yield 'Empty extra config returns empty array' => [
+            'extraConfig' => [],
+            'expectedPaths' => [],
+            'expectedOutput' => '',
+        ];
+        yield 'Other extra configuration are kept' => [
+            'extraConfig' => [
+                'typo3/cms' => [
+                    'extension-key' => 'some_extension_key',
+                ],
+            ],
+            'expectedPaths' => [],
+            'expectedOutput' => '',
+        ];
+        yield 'Non-array extra->typo3/testing-framework/fixture-extension-paths value is removed' => [
+            'extraConfig' => [
+                'typo3/testing-framework' => [
+                    'fixture-extension-paths' => false,
+                ],
+            ],
+            'expectedPaths' => [],
+            'expectedOutput' => '<warning>extra->typo3/testing-framework/fixture-extension-paths must be an array, "boolean" given.</warning>' . PHP_EOL,
+        ];
+        yield 'Non-array extra->typo3/testing-framework/fixture-extension-paths value is removed keeping other settings' => [
+            'extraConfig' => [
+                'typo3/testing-framework' => [
+                    'other-configuration' => true,
+                    'fixture-extension-paths' => false,
+                ],
+            ],
+            'expectedPaths' => [],
+            'expectedOutput' => '<warning>extra->typo3/testing-framework/fixture-extension-paths must be an array, "boolean" given.</warning>' . PHP_EOL,
+        ];
+        yield 'non-relative fixture extension paths are discarded and outputs warning' => [
+            'extraConfig' => [
+                'typo3/testing-framework' => [
+                    'fixture-extension-paths' => [
+                        '/absolute/path',
+                    ],
+                ],
+            ],
+            'expectedPaths' => [],
+            'expectedOutput' => sprintf(
+                '<warning>Test fixture extension path must be a subdirectory of Composer root directory. Skip "%s".</warning>' . PHP_EOL,
+                '/absolute/path'
+            ),
+        ];
+        yield 'non-relative fixture exetension paths are discarded and outputs warning, but keeps relative paths' => [
+            'extraConfig' => [
+                'typo3/testing-framework' => [
+                    'fixture-extension-paths' => [
+                        '/absolute/path',
+                        'relative/path',
+                    ],
+                ],
+            ],
+            'expectedPaths' => [
+                'relative/path',
+            ],
+            'expectedOutput' => sprintf(
+                '<warning>Test fixture extension path must be a subdirectory of Composer root directory. Skip "%s".</warning>' . PHP_EOL,
+                '/absolute/path'
+            ),
+        ];
+        yield 'relative path leaving composer root is discarded and outputs warning' => [
+            'extraConfig' => [
+                'typo3/testing-framework' => [
+                    'fixture-extension-paths' => [
+                        'relative/../../path-outside-composer-root',
+                    ],
+                ],
+            ],
+            'expectedPaths' => [],
+            'expectedOutput' => sprintf(
+                '<warning>Test fixture extension path must be a subdirectory of Composer root directory. Skip "%s".</warning>' . PHP_EOL,
+                'relative/../../path-outside-composer-root'
+            ),
+        ];
+    }
+
+    /**
+     * @dataProvider loadCreatesConfigWithExpectedPathsDataSets
+     * @test
+     */
+    public function loadCreatesConfigWithExpectedPaths(array $extraConfig, array $expectedPaths, string $expectedOutput): void
+    {
+        $rootPackage = new RootPackage('fake/package', '1.0.0', '1.0.0.0');
+        $rootPackage->setExtra($extraConfig);
+        $composerConfig = new \Composer\Config(false, '/fake/root');
+        $composer = new Composer();
+        $composer->setPackage($rootPackage);
+        $composer->setConfig($composerConfig);
+        $bufferedIO = new BufferIO();
+        $config = Config::load($composer, $bufferedIO);
+        self::assertInstanceOf(Config::class, $config);
+        self::assertSame($expectedPaths, $config->fixtureExtensionPaths(Config::FLAG_PATHS_RELATIVE));
+        self::assertSame($expectedOutput, $bufferedIO->getOutput());
+    }
+}

--- a/tests/Unit/Plugin/ConfigTest.php
+++ b/tests/Unit/Plugin/ConfigTest.php
@@ -2,47 +2,32 @@
 
 declare(strict_types=1);
 
-namespace SBUERK\TestFixtureExtensionAdopter\Tests\Unit\Plugin;
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace SBUERK\FixturePackages\Tests\Unit\Plugin;
 
 use Composer\Composer;
 use Composer\IO\BufferIO;
 use Composer\Package\RootPackage;
-use PHPUnit\Framework\TestCase;
-use SBUERK\TestFixtureExtensionAdopter\Plugin\Config;
+use SBUERK\FixturePackages\Plugin\Config;
+use SBUERK\FixturePackages\Tests\Unit\BaseUnitTestCase;
 
-final class ConfigTest extends TestCase
+/**
+ * @covers \SBUERK\FixturePackages\Plugin\Config
+ */
+final class ConfigTest extends BaseUnitTestCase
 {
-
-    public function tearDown(): void
-    {
-        /**
-         * Reset static property {@see Config::$instance} holding instance used within {@see Config::load()}. This
-         * essential, otherwise tests will fail for different scenarios.
-         */
-        $this->createSubjectClassReflection()->setStaticPropertyValue('instance', null);
-        parent::tearDown();
-    }
-
-    private function createSubject(string $baseDir = '/fake/root'): Config
-    {
-        return new Config($baseDir);
-    }
-
-    private function createSubjectMethodReflection(string $method): \ReflectionMethod
-    {
-        $methodReflection = $this->createSubjectClassReflection()->getMethod($method);
-        if (PHP_VERSION_ID < 801000) {
-            $methodReflection->setAccessible(true);
-        }
-        $methodReflection->setAccessible(true);
-        return $methodReflection;
-    }
-
-    private function createSubjectClassReflection(): \ReflectionClass
-    {
-        return new \ReflectionClass(Config::class);
-    }
-
     public static function normalizePathDataSets(): \Generator
     {
         yield 'Empty string returns empty string' => [
@@ -55,11 +40,11 @@ final class ConfigTest extends TestCase
         ];
         yield 'Drive letter is kept' => [
             'value' => 'C:/',
-            'expectedValue' => 'C:/',
+            'expectedValue' => 'C:',
         ];
         yield 'Windows path backslash is normalized to slash keeping drive letter' => [
             'value' => 'C:\\',
-            'expectedValue' => 'C:/',
+            'expectedValue' => 'C:',
         ];
         yield 'Unix path are trimmed' => [
             'value' => '/some/path/',
@@ -79,10 +64,14 @@ final class ConfigTest extends TestCase
         ];
     }
 
+    /**
+     * @dataProvider normalizePathDataSets
+     * @test
+     */
     public function normalizePathReturnsExpectedValue(string $value, string $expectedValue): void
     {
-        $realpathMethodInvoker = $this->createSubjectMethodReflection('normalizePath');
-        self::assertSame($expectedValue, $realpathMethodInvoker->invoke($this->createSubject(), $value));
+        $realpathMethodInvoker = $this->createClassMethodInvoker(Config::class, 'normalizePath');
+        self::assertSame($expectedValue, $realpathMethodInvoker->invoke(new Config('/fake/root'), $value));
     }
 
     public static function realpathDataSets(): \Generator
@@ -135,8 +124,8 @@ final class ConfigTest extends TestCase
      */
     public function realpathReturnsExpectedValue(string $baseDir, string $path, string $expectedPath): void
     {
-        $realpathMethodInvoker = $this->createSubjectMethodReflection('realpath');
-        self::assertSame($expectedPath, $realpathMethodInvoker->invoke($this->createSubject($baseDir), $path));
+        $realpathMethodInvoker = $this->createClassMethodInvoker(Config::class, 'realpath');
+        self::assertSame($expectedPath, $realpathMethodInvoker->invoke(new Config($baseDir), $path));
     }
 
     public static function handleRootPackageExtraConfigReturnsExpectedConfigArrayDataSets(): \Generator
@@ -159,42 +148,42 @@ final class ConfigTest extends TestCase
             ],
             'expectedOutput' => '',
         ];
-        yield 'Non-array extra->typo3/testing-framework/fixture-extension-paths value is removed' => [
+        yield 'Non-array extra->sbuerk/fixture-packages/paths value is removed' => [
             'extraConfig' => [
-                'typo3/testing-framework' => [
-                    'fixture-extension-paths' => false,
+                'sbuerk/fixture-packages' => [
+                    'paths' => false,
                 ],
             ],
             'expectedConfigArray' => [
-                'typo3/testing-framework' => [],
+                'sbuerk/fixture-packages' => [],
             ],
-            'expectedOutput' => '<warning>extra->typo3/testing-framework/fixture-extension-paths must be an array, "boolean" given.</warning>' . PHP_EOL,
+            'expectedOutput' => '<warning>extra->sbuerk/fixture-packages/paths must be an array, "boolean" given.</warning>' . PHP_EOL,
         ];
-        yield 'Non-array extra->typo3/testing-framework/fixture-extension-paths value is removed keeping other settings' => [
+        yield 'Non-array extra->sbuerk/fixture-packages/paths value is removed keeping other settings' => [
             'extraConfig' => [
-                'typo3/testing-framework' => [
+                'sbuerk/fixture-packages' => [
                     'other-configuration' => true,
-                    'fixture-extension-paths' => false,
+                    'paths' => false,
                 ],
             ],
             'expectedConfigArray' => [
-                'typo3/testing-framework' => [
+                'sbuerk/fixture-packages' => [
                     'other-configuration' => true,
                 ],
             ],
-            'expectedOutput' => '<warning>extra->typo3/testing-framework/fixture-extension-paths must be an array, "boolean" given.</warning>' . PHP_EOL,
+            'expectedOutput' => '<warning>extra->sbuerk/fixture-packages/paths must be an array, "boolean" given.</warning>' . PHP_EOL,
         ];
         yield 'non-relative fixture extension paths are discarded and outputs warning' => [
             'extraConfig' => [
-                'typo3/testing-framework' => [
-                    'fixture-extension-paths' => [
+                'sbuerk/fixture-packages' => [
+                    'paths' => [
                         '/absolute/path',
                     ],
                 ],
             ],
             'expectedConfigArray' => [
-                'typo3/testing-framework' => [
-                    'fixture-extension-paths' => [],
+                'sbuerk/fixture-packages' => [
+                    'paths' => [],
                 ],
             ],
             'expectedOutput' => sprintf(
@@ -204,16 +193,16 @@ final class ConfigTest extends TestCase
         ];
         yield 'non-relative fixture exetension paths are discarded and outputs warning, but keeps relative paths' => [
             'extraConfig' => [
-                'typo3/testing-framework' => [
-                    'fixture-extension-paths' => [
+                'sbuerk/fixture-packages' => [
+                    'paths' => [
                         '/absolute/path',
                         'relative/path',
                     ],
                 ],
             ],
             'expectedConfigArray' => [
-                'typo3/testing-framework' => [
-                    'fixture-extension-paths' => [
+                'sbuerk/fixture-packages' => [
+                    'paths' => [
                         'relative/path',
                     ],
                 ],
@@ -225,15 +214,15 @@ final class ConfigTest extends TestCase
         ];
         yield 'relative path leaving composer root is discarded and outputs warning' => [
             'extraConfig' => [
-                'typo3/testing-framework' => [
-                    'fixture-extension-paths' => [
+                'sbuerk/fixture-packages' => [
+                    'paths' => [
                         'relative/../../path-outside-composer-root',
                     ],
                 ],
             ],
             'expectedConfigArray' => [
-                'typo3/testing-framework' => [
-                    'fixture-extension-paths' => [],
+                'sbuerk/fixture-packages' => [
+                    'paths' => [],
                 ],
             ],
             'expectedOutput' => sprintf(
@@ -251,12 +240,11 @@ final class ConfigTest extends TestCase
     {
         $rootPackage = new RootPackage('fake/package', '1.0.0', '1.0.0.0');
         $rootPackage->setExtra($extraConfig);
-        $methodReflection =  $this->createSubjectMethodReflection('handleRootPackageExtraConfig');
+        $methodReflection =  $this->createClassMethodInvoker(Config::class, 'handleRootPackageExtraConfig');
         $bufferedIO = new BufferIO();
-        self::assertSame($expectedConfigArray, $methodReflection->invoke($this->createSubject(), $bufferedIO, $rootPackage));
+        self::assertSame($expectedConfigArray, $methodReflection->invoke(new Config('/fake/root'), $bufferedIO, $rootPackage));
         self::assertSame($expectedOutput, $bufferedIO->getOutput());
     }
-
 
     public static function loadCreatesConfigWithExpectedPathsDataSets(): \Generator
     {
@@ -274,29 +262,29 @@ final class ConfigTest extends TestCase
             'expectedPaths' => [],
             'expectedOutput' => '',
         ];
-        yield 'Non-array extra->typo3/testing-framework/fixture-extension-paths value is removed' => [
+        yield 'Non-array extra->sbuerk/fixture-packages/paths value is removed' => [
             'extraConfig' => [
-                'typo3/testing-framework' => [
-                    'fixture-extension-paths' => false,
+                'sbuerk/fixture-packages' => [
+                    'paths' => false,
                 ],
             ],
             'expectedPaths' => [],
-            'expectedOutput' => '<warning>extra->typo3/testing-framework/fixture-extension-paths must be an array, "boolean" given.</warning>' . PHP_EOL,
+            'expectedOutput' => '<warning>extra->sbuerk/fixture-packages/paths must be an array, "boolean" given.</warning>' . PHP_EOL,
         ];
-        yield 'Non-array extra->typo3/testing-framework/fixture-extension-paths value is removed keeping other settings' => [
+        yield 'Non-array extra->sbuerk/fixture-packages/paths value is removed keeping other settings' => [
             'extraConfig' => [
-                'typo3/testing-framework' => [
+                'sbuerk/fixture-packages' => [
                     'other-configuration' => true,
-                    'fixture-extension-paths' => false,
+                    'paths' => false,
                 ],
             ],
             'expectedPaths' => [],
-            'expectedOutput' => '<warning>extra->typo3/testing-framework/fixture-extension-paths must be an array, "boolean" given.</warning>' . PHP_EOL,
+            'expectedOutput' => '<warning>extra->sbuerk/fixture-packages/paths must be an array, "boolean" given.</warning>' . PHP_EOL,
         ];
         yield 'non-relative fixture extension paths are discarded and outputs warning' => [
             'extraConfig' => [
-                'typo3/testing-framework' => [
-                    'fixture-extension-paths' => [
+                'sbuerk/fixture-packages' => [
+                    'paths' => [
                         '/absolute/path',
                     ],
                 ],
@@ -309,8 +297,8 @@ final class ConfigTest extends TestCase
         ];
         yield 'non-relative fixture exetension paths are discarded and outputs warning, but keeps relative paths' => [
             'extraConfig' => [
-                'typo3/testing-framework' => [
-                    'fixture-extension-paths' => [
+                'sbuerk/fixture-packages' => [
+                    'paths' => [
                         '/absolute/path',
                         'relative/path',
                     ],
@@ -326,8 +314,8 @@ final class ConfigTest extends TestCase
         ];
         yield 'relative path leaving composer root is discarded and outputs warning' => [
             'extraConfig' => [
-                'typo3/testing-framework' => [
-                    'fixture-extension-paths' => [
+                'sbuerk/fixture-packages' => [
+                    'paths' => [
                         'relative/../../path-outside-composer-root',
                     ],
                 ],
@@ -355,7 +343,7 @@ final class ConfigTest extends TestCase
         $bufferedIO = new BufferIO();
         $config = Config::load($composer, $bufferedIO);
         self::assertInstanceOf(Config::class, $config);
-        self::assertSame($expectedPaths, $config->fixtureExtensionPaths(Config::FLAG_PATHS_RELATIVE));
+        self::assertSame($expectedPaths, $config->paths(Config::FLAG_PATHS_RELATIVE));
         self::assertSame($expectedOutput, $bufferedIO->getOutput());
     }
 }

--- a/tests/Unit/Plugin/FixturePackagesServiceTest.php
+++ b/tests/Unit/Plugin/FixturePackagesServiceTest.php
@@ -1,0 +1,303 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace SBUERK\FixturePackages\Tests\Unit\Plugin;
+
+use Composer\Advisory\Auditor;
+use Composer\Composer;
+use Composer\Factory;
+use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilterFactory;
+use Composer\Installer;
+use Composer\IO\BufferIO;
+use Composer\Package\RootPackage;
+use Composer\Repository\RepositoryInterface;
+use Composer\Repository\RepositoryManager;
+use Composer\Util\Filesystem;
+use SBUERK\FixturePackages\Composer\Repository\FixturePathRepository;
+use SBUERK\FixturePackages\Plugin\Config;
+use SBUERK\FixturePackages\Plugin\FixturePackagesService;
+use SBUERK\FixturePackages\Tests\Unit\BaseUnitTestCase;
+use Symfony\Component\Console\Output\StreamOutput;
+
+/**
+ * @covers \SBUERK\FixturePackages\Plugin\FixturePackagesService
+ */
+final class FixturePackagesServiceTest extends BaseUnitTestCase
+{
+    /**
+     * @return string[]
+     */
+    private function getRepositoryPackageNames(RepositoryInterface $repository): array
+    {
+        $names = [];
+        foreach ($repository->getPackages() as $package) {
+            self::assertSame('fixture-path', $package->getDistType());
+            $names[] = $package->getName();
+        }
+        return $names;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getRepositoryManagerPackageNames(RepositoryManager $repositoryManager): array
+    {
+        $names = [];
+        foreach ($repositoryManager->getRepositories() as $repository) {
+            self::assertInstanceOf(FixturePathRepository::class, $repository);
+            foreach ($repository->getPackages() as $package) {
+                self::assertSame('fixture-path', $package->getDistType());
+                $names[] = $package->getName();
+            }
+        }
+        return $names;
+    }
+
+    public static function createRepositoryForPathDataSets(): \Generator
+    {
+        $baseDir = (new Filesystem())->normalizePath(__DIR__ . '/../../Fixtures/fixture-path-repository-structure');
+        yield 'one subfolder level works for wildcard path' => [
+            'extra' => [
+                'sbuerk/fixture-packages' => [
+                    'paths' => [
+                        'Fixtures/Extensions/*',
+                    ],
+                ],
+            ],
+            'baseDir' => $baseDir,
+            'path' => 'Fixtures/Extensions/*',
+            'expectedPackageNames' => [
+                'vendor/test-extension-one',
+                'vendor/test-extension-two',
+            ],
+        ];
+        yield 'two subfolder level works for two wildcard path' => [
+            'extra' => [
+                'sbuerk/fixture-packages' => [
+                    'paths' => [
+                        'Fixtures/*/*',
+                    ],
+                ],
+            ],
+            'baseDir' => $baseDir,
+            'path' => 'Fixtures/*/*',
+            'expectedPackageNames' => [
+                'vendor/test-extension-one',
+                'vendor/test-extension-two',
+                'vendor/test-extension-three',
+                'vendor/test-package-two',
+                'vendor/test-package-one',
+            ],
+        ];
+        yield 'multi path wildcards works' => [
+            'extra' => [
+                'sbuerk/fixture-packages' => [
+                    'paths' => [
+                        'Packages/*/Fixtures/Extensions/*',
+                    ],
+                ],
+            ],
+            'baseDir' => $baseDir,
+            'path' => 'Packages/*/Fixtures/Extensions/*',
+            'expectedPackageNames' => [
+                'vendor/test-extension-four',
+                'vendor/test-extension-five',
+            ],
+        ];
+        yield 'Package path without wildcard works' => [
+            'extra' => [
+                'sbuerk/fixture-packages' => [
+                    'paths' => [
+                        'Fixtures/Extensions/extension-one',
+                    ],
+                ],
+            ],
+            'baseDir' => $baseDir,
+            'path' => 'Fixtures/Extensions/extension-one',
+            'expectedPackageNames' => [
+                'vendor/test-extension-one',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider createRepositoryForPathDataSets
+     * @test
+     */
+    public function createRepositoryForPathReturnsRepositoryWithExpectedPackageNames(
+        array $extra,
+        string $baseDir,
+        string $path,
+        array $expectedPackageNames
+    ): void {
+        chdir($baseDir);
+        $composerConfig = new \Composer\Config(false, $baseDir);
+        $rootPackage = new RootPackage('fake/root', '1.0.0', '1.0.0.0');
+        $rootPackage->setRepositories([
+            // Disable packagist to avoid network/internet calls
+            'packagist' => false,
+        ]);
+        $rootPackage->setExtra($extra);
+        $composer = new Composer();
+        $composer->setConfig($composerConfig);
+        $composer->setPackage($rootPackage);
+        $subject = new FixturePackagesService();
+        $bufferedIo = new BufferIO();
+        $invokableCreateRepositoryManager = $this->createClassMethodInvoker($subject, 'createRepositoryManager');
+        $invokableCreateRepositoryForPath = $this->createClassMethodInvoker($subject, 'createRepositoryForPath');
+        $repositoryManager = $invokableCreateRepositoryManager->invoke($subject, $bufferedIo, $composer);
+        $repository = $invokableCreateRepositoryForPath->invoke($subject, $repositoryManager, $composer, $bufferedIo, $path);
+        self::assertInstanceOf(RepositoryInterface::class, $repository);
+        self::assertInstanceOf(FixturePathRepository::class, $repository);
+        self::assertSame($expectedPackageNames, $this->getRepositoryPackageNames($repository));
+    }
+
+    /**
+     * @dataProvider createRepositoryForPathDataSets
+     * @test
+     */
+    public function createPreparedRepositoryManagerReturnsRepositoryManagerWithExpectedRepositoriesAndPackages(
+        array $extra,
+        string $baseDir,
+        string $path,
+        array $expectedPackageNames
+    ): void {
+        chdir($baseDir);
+        $bufferedIo = new BufferIO();
+        $composerConfig = new \Composer\Config(false, $baseDir);
+        $rootPackage = new RootPackage('fake/root', '1.0.0', '1.0.0.0');
+        $rootPackage->setExtra($extra);
+        $rootPackage->setRepositories([
+            // Disable packagist to avoid network/internet calls
+            'packagist.org' => false,
+        ]);
+        $composer = new Composer();
+        $composer->setConfig($composerConfig);
+        $composer->setPackage($rootPackage);
+        $config = Config::load($composer, $bufferedIo);
+        $subject = new FixturePackagesService();
+        $invokablePrepareRepositoryManager = $this->createClassMethodInvoker($subject, 'createPreparedRepositoryManager');
+        $repositoryManager = $invokablePrepareRepositoryManager->invoke($subject, $config, $composer, $bufferedIo);
+        $packageNames = $this->getRepositoryManagerPackageNames($repositoryManager);
+        self::assertSame($expectedPackageNames, $packageNames);
+    }
+
+    public static function createExportPackagesArrayDataSets(): \Generator
+    {
+        $baseDir = (new Filesystem())->normalizePath(__DIR__ . '/../../Fixtures/fixture-path-repository-structure');
+        yield 'exported data has expected structure' => [
+            'extra' => [
+                'sbuerk/fixture-packages' => [
+                    'paths' => [
+                        'Fixtures/Extensions/*',
+                    ],
+                ],
+            ],
+            'baseDir' => $baseDir,
+            'expectedExportArray' => [
+                'vendor/test-extension-one' => [
+                    'name' => 'vendor/test-extension-one',
+                    'type' => 'typo3-cms-extension',
+                    'path' => '../../Fixtures/Extensions/extension-one',
+                    'extra' => [
+                        'typo3/cms' => [
+                            'extension-key' => 'extension_one',
+                        ],
+                    ],
+                ],
+                'vendor/test-extension-two' => [
+                    'name' => 'vendor/test-extension-two',
+                    'type' => 'typo3-cms-extension',
+                    'path' => '../../Fixtures/Extensions/extension-two',
+                    'extra' => [
+                        'typo3/cms' => [
+                            'extension-key' => 'extension_two',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider createExportPackagesArrayDataSets
+     * @test
+     */
+    public function createExportPackagesArrayReturnsExpectedArray(
+        array $extra,
+        string $baseDir,
+        array $expectedExportArray
+    ): void {
+        chdir($baseDir);
+        $bufferedIo = new BufferIO();
+        $composerConfig = new \Composer\Config(false, $baseDir);
+        $rootPackage = new RootPackage('fake/root', '1.0.0', '1.0.0.0');
+        $rootPackage->setExtra($extra);
+        $rootPackage->setRepositories([
+            // Disable packagist to avoid network/internet calls
+            'packagist.org' => false,
+        ]);
+        $composer = new Composer();
+        $composer->setConfig($composerConfig);
+        $composer->setPackage($rootPackage);
+        $config = Config::load($composer, $bufferedIo);
+        $subject = new FixturePackagesService();
+        $invokableGetTestFixturePackages = $this->createClassMethodInvoker($subject, 'getTestFixturePackages');
+        $packages = array_values($invokableGetTestFixturePackages->invoke($subject, $config, $composer, $bufferedIo, []));
+        $invokableCreateExportPackagesArray = $this->createClassMethodInvoker($subject, 'createExportPackagesArray');
+        self::assertSame($expectedExportArray, $invokableCreateExportPackagesArray->invoke($subject, $config, $baseDir . '/vendor/sbuerk', ...$packages));
+    }
+
+    /**
+     * Test with composer install example - not used yet.
+     *
+     * @todo Create composer install tests as e2e tests.
+     * @todo Handle stdErr (PHP warnings not possible to read files due to missing exist checks in composer).
+     */
+    private function composerInstallExample(): void
+    {
+        // @todo Implement a better recursive cleanup/recursive folder removal code. Should be part of tearDown().
+        `rm -rf tests/Fixtures/fixture-path-repository-structure/vendor tests/Fixtures/fixture-path-repository-structure/composer.lock`;
+        $baseDir = realpath(__DIR__ . '/../../Fixtures/fixture-path-repository-structure');
+        chdir($baseDir);
+        $bufferedIO = new BufferIO('', StreamOutput::VERBOSITY_DEBUG);
+        $composerConfig = Factory::createConfig($bufferedIO, $baseDir);
+        $composer = Factory::create($bufferedIO);
+        $install = Installer::create($bufferedIO, $composer);
+        $composer->getInstallationManager()->setOutputProgress(false);
+        $rootPackage = $composer->getPackage();
+        $install
+            ->setDryRun(false)
+            ->setDownloadOnly(false)
+            ->setVerbose(true)
+            ->setPreferSource(true)
+            ->setPreferDist(false)
+            ->setDevMode(true)
+            ->setDumpAutoloader(true)
+            ->setOptimizeAutoloader(false)
+            ->setClassMapAuthoritative(false)
+            ->setApcuAutoloader(false, null)
+            ->setPlatformRequirementFilter(PlatformRequirementFilterFactory::ignoreNothing())
+            ->setAudit(false)
+            ->setErrorOnAudit(false)
+            ->setAuditFormat(Auditor::FORMAT_TABLE)
+        ;
+        $install->run();
+        $output = $bufferedIO->getOutput();
+        $b = 1;
+    }
+}

--- a/tests/Unit/Plugin/Util/AutoloadMergerTest.php
+++ b/tests/Unit/Plugin/Util/AutoloadMergerTest.php
@@ -1,0 +1,389 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace SBUERK\FixturePackages\Tests\Unit\Plugin\Util;
+
+use Composer\IO\NullIO;
+use Composer\Package\BasePackage;
+use Composer\Package\Package;
+use Composer\Package\PackageInterface;
+use Composer\Package\RootPackage;
+use Composer\Package\RootPackageInterface;
+use SBUERK\FixturePackages\Plugin\Util\AutoloadMerger;
+use SBUERK\FixturePackages\Tests\Unit\BaseUnitTestCase;
+
+/**
+ * @covers \SBUERK\FixturePackages\Plugin\Util\AutoloadMerger
+ */
+final class AutoloadMergerTest extends BaseUnitTestCase
+{
+    /**
+     * Create pseudo package instance to be used in tests.
+     *
+     * @param string $name
+     * @param string $sourceUrl
+     * @param array{"psr-0"?: array<string, array<string>|string>, "psr-4"?: array<string, array<string>|string>, classmap?: list<string>, files?: list<string>} $autoload
+     * @param array{"psr-0"?: array<string, array<string>|string>, "psr-4"?: array<string, array<string>|string>, classmap?: list<string>, files?: list<string>} $devAutoload
+     * @return BasePackage
+     */
+    private static function createPackage(
+        string $name,
+        string $sourceUrl,
+        array $autoload = [],
+        array $devAutoload = []
+    ): BasePackage {
+        $package = new Package($name, '1.0.0', '1.0.0.0');
+        $package->setType('library');
+        $package->setSourceType('');
+        $package->setSourceUrl($sourceUrl);
+        $package->setAutoload($autoload);
+        $package->setDevAutoload($devAutoload);
+        return $package;
+    }
+
+    /**
+     * Create pseudo package instance to be used in tests.
+     *
+     * @param string $name
+     * @param array{"psr-0"?: array<string, array<string>|string>, "psr-4"?: array<string, array<string>|string>, classmap?: list<string>, files?: list<string>} $autoload
+     * @param array{"psr-0"?: array<string, array<string>|string>, "psr-4"?: array<string, array<string>|string>, classmap?: list<string>, files?: list<string>} $devAutoload
+     * @return RootPackageInterface
+     */
+    private static function createRootPackage(
+        string $name,
+        array $autoload = [],
+        array $devAutoload = []
+    ): RootPackageInterface {
+        $package = new RootPackage($name, '1.0.0', '1.0.0.0');
+        $package->setType('project');
+        $package->setAutoload($autoload);
+        $package->setDevAutoload($devAutoload);
+        return $package;
+    }
+
+    public static function modifyPackageNamespacePathDataSets(): \Generator
+    {
+        yield 'namespacePath is prefixed with package sourceUrl' => [
+            'package' => self::createPackage('fake/package', 'some/path/fake_package'),
+            'namespacePath' => 'Classes',
+            'expectedReturnValue' => 'some/path/fake_package/Classes',
+        ];
+        yield 'namespacePath with ending slash is prefixed with package sourceUrl' => [
+            'package' => self::createPackage('fake/package', 'some/path/fake_package'),
+            'namespacePath' => 'Classes/',
+            'expectedReturnValue' => 'some/path/fake_package/Classes',
+        ];
+        yield 'back-and-forth relative namespacePath is prefixed with package sourceUrl and normalized' => [
+            'package' => self::createPackage('fake/package', 'some/path/fake_package'),
+            'namespacePath' => 'Classes/Subfolder/../../src',
+            'expectedReturnValue' => 'some/path/fake_package/src',
+        ];
+    }
+
+    /**
+     * @dataProvider modifyPackageNamespacePathDataSets
+     * @test
+     */
+    public function modifyPackageNamespacePathReturnsExpectedString(
+        PackageInterface $package,
+        string $namespacePath,
+        string $expectedReturnValue
+    ): void {
+        $invoker = $this->createClassMethodInvoker(AutoloadMerger::class, 'modifyPackageNamespacePath');
+        self::assertSame($expectedReturnValue, $invoker->invoke(new AutoloadMerger(), $package, $namespacePath));
+    }
+
+    public static function mergePsrNamespaceDataSets(): \Generator
+    {
+        // psr-4
+        yield 'Non existing PSR-4 namespace is added along with PSR-4 main section, not creating unrelated sections' => [
+            'rootPackage' => self::createRootPackage('project/root'),
+            'package' => self::createPackage('fake/package', 'packages/fake_package'),
+            'psr' => 'psr-4',
+            'namespace' => 'Vendor\\Package\\',
+            'namespacePath' => 'Classes',
+            'expectedRootPackageAutoloadDev' => [
+                'psr-4' => [
+                    'Vendor\\Package\\' => 'packages/fake_package/Classes',
+                ],
+            ],
+        ];
+        yield 'Existing PSR-4 namespace with matching path does not convert to array, not creating unrelated sections' => [
+            'rootPackage' => self::createRootPackage('project/root', [], ['psr-4' => ['Vendor\\Package\\' => 'packages/fake_package/Classes']]),
+            'package' => self::createPackage('fake/package', 'packages/fake_package'),
+            'psr' => 'psr-4',
+            'namespace' => 'Vendor\\Package\\',
+            'namespacePath' => 'Classes',
+            'expectedRootPackageAutoloadDev' => [
+                'psr-4' => [
+                    'Vendor\\Package\\' => 'packages/fake_package/Classes',
+                ],
+            ],
+        ];
+        yield 'Existing PSR-4 namespace adds additional path converting to array, not creating unrelated sections' => [
+            'rootPackage' => self::createRootPackage('project/root', [], ['psr-4' => ['Vendor\\Package\\' => 'packages/main_package/src']]),
+            'package' => self::createPackage('fake/package', 'packages/fake_package'),
+            'psr' => 'psr-4',
+            'namespace' => 'Vendor\\Package\\',
+            'namespacePath' => 'Classes',
+            'expectedRootPackageAutoloadDev' => [
+                'psr-4' => [
+                    'Vendor\\Package\\' => [
+                        'packages/main_package/src',
+                        'packages/fake_package/Classes',
+                    ],
+                ],
+            ],
+        ];
+        // psr-0
+        yield 'Non existing PSR-0 namespace is added along with PSR-4 main section, not creating unrelated sections' => [
+            'rootPackage' => self::createRootPackage('project/root'),
+            'package' => self::createPackage('fake/package', 'packages/fake_package'),
+            'psr' => 'psr-0',
+            'namespace' => 'Vendor\\Package\\',
+            'namespacePath' => 'Classes',
+            'expectedRootPackageAutoloadDev' => [
+                'psr-0' => [
+                    'Vendor\\Package\\' => 'packages/fake_package/Classes',
+                ],
+            ],
+        ];
+        yield 'Existing PSR-0 namespace with matching path does not convert to array, not creating unrelated sections' => [
+            'rootPackage' => self::createRootPackage('project/root', [], ['psr-0' => ['Vendor\\Package\\' => 'packages/fake_package/Classes']]),
+            'package' => self::createPackage('fake/package', 'packages/fake_package'),
+            'psr' => 'psr-0',
+            'namespace' => 'Vendor\\Package\\',
+            'namespacePath' => 'Classes',
+            'expectedRootPackageAutoloadDev' => [
+                'psr-0' => [
+                    'Vendor\\Package\\' => 'packages/fake_package/Classes',
+                ],
+            ],
+        ];
+        yield 'Existing PSR-0 namespace adds additional path converting to array, not creating unrelated sections' => [
+            'rootPackage' => self::createRootPackage('project/root', [], ['psr-0' => ['Vendor\\Package\\' => 'packages/main_package/src']]),
+            'package' => self::createPackage('fake/package', 'packages/fake_package'),
+            'psr' => 'psr-0',
+            'namespace' => 'Vendor\\Package\\',
+            'namespacePath' => 'Classes',
+            'expectedRootPackageAutoloadDev' => [
+                'psr-0' => [
+                    'Vendor\\Package\\' => [
+                        'packages/main_package/src',
+                        'packages/fake_package/Classes',
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider mergePsrNamespaceDataSets
+     * @test
+     */
+    public function mergePsrNamespaceModifiesRootPackageAsExpected(
+        RootPackageInterface $rootPackage,
+        BasePackage $package,
+        string $psr,
+        string $namespace,
+        string $namespacePath,
+        array $expectedRootPackageAutoloadDev
+    ): void {
+        $io = new NullIO();
+        $invoker = $this->createClassMethodInvoker(AutoloadMerger::class, 'mergePsrNamespace');
+        $invoker->invoke(new AutoloadMerger(), $io, $rootPackage, $package, $psr, $namespace, $namespacePath);
+        self::assertSame($expectedRootPackageAutoloadDev, $rootPackage->getDevAutoload());
+    }
+
+    public static function mergePsrNamespacesDataSets(): \Generator
+    {
+        yield 'psr-4 namespaces are merged to root package' => [
+            'rootPackage' => self::createRootPackage('project/root'),
+            'package' => self::createPackage('fake/package', 'packages/fake_package', ['psr-4' => ['Vendor\\Package\\' => 'Classes', 'Vendor\\Package\\SecondNamespace\\' => 'src']]),
+            'psr' => 'psr-4',
+            'expectedDevAutoload' => [
+                'psr-4' => [
+                    'Vendor\\Package\\' => 'packages/fake_package/Classes',
+                    'Vendor\\Package\\SecondNamespace\\' => 'packages/fake_package/src',
+                ],
+            ],
+        ];
+    }
+
+    public static function mergeSimpleNamespaceDataSets(): \Generator
+    {
+        yield 'files namespaces are adopted' => [
+            'rootPackage' => self::createRootPackage('project/root'),
+            'package' => self::createPackage(
+                'fake/package',
+                'packages/fake_package',
+                [
+                    'files' => [
+                        'some/path/',
+                        'other/single.php',
+                    ],
+                ]
+            ),
+            'type' => 'files',
+            'expectedDevAutoload' => [
+                'files' => [
+                    'packages/fake_package/some/path',
+                    'packages/fake_package/other/single.php',
+                ],
+            ],
+        ];
+        yield 'classmap namespaces are adopted' => [
+            'rootPackage' => self::createRootPackage('project/root'),
+            'package' => self::createPackage(
+                'fake/package',
+                'packages/fake_package',
+                [
+                    'classmap' => [
+                        'some/path/',
+                        'other/single.php',
+                    ],
+                ]
+            ),
+            'type' => 'classmap',
+            'expectedDevAutoload' => [
+                'classmap' => [
+                    'packages/fake_package/some/path',
+                    'packages/fake_package/other/single.php',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider mergeSimpleNamespaceDataSets
+     * @test
+     */
+    public function mergeSimpleNamespaceModifiesRootPackageAsExpected(
+        RootPackageInterface $rootPackage,
+        BasePackage $package,
+        string $type,
+        array $expectedDevAutoload
+    ): void {
+        $io = new NullIO();
+        $invoker = $this->createClassMethodInvoker(AutoloadMerger::class, 'mergeSimpleNamespace');
+        $invoker->invoke(new AutoloadMerger(), $io, $rootPackage, $package, $type);
+        self::assertSame($expectedDevAutoload, $rootPackage->getDevAutoload());
+    }
+
+    /**
+     * @dataProvider mergePsrNamespacesDataSets
+     * @test
+     */
+    public function mergePsrNamespacesModifiesRootPackageAsExpected(
+        RootPackageInterface $rootPackage,
+        BasePackage $package,
+        string $psr,
+        array $expectedDevAutoload
+    ): void {
+        $io = new NullIO();
+        $invoker = $this->createClassMethodInvoker(AutoloadMerger::class, 'mergePsrNamespaces');
+        $invoker->invoke(new AutoloadMerger(), $io, $rootPackage, $package, $psr);
+        self::assertSame($expectedDevAutoload, $rootPackage->getDevAutoload());
+    }
+
+    public static function mergeAllNamespacesDataSets(): \Generator
+    {
+        yield 'psr-0 and psr-4 namespaces are merged to root-package' => [
+            'rootPackage' => self::createRootPackage('project/root'),
+            'package' => self::createPackage('fake/package', 'packages/fake_package', ['psr-0' => ['Vendor_Namespace\\' => 'src-psr0'], 'psr-4' => ['Vendor\\Package\\' => 'src-psr4']]),
+            'expectedDevAutoload' => [
+                'psr-0' => [
+                    'Vendor_Namespace\\' => 'packages/fake_package/src-psr0',
+                ],
+                'psr-4' => [
+                    'Vendor\\Package\\' => 'packages/fake_package/src-psr4',
+                ],
+            ],
+        ];
+        yield 'psr-0 and psr-4 namespaces are merged with same root-package namespaces converted to array' => [
+            'rootPackage' => self::createRootPackage('project/root', [], ['psr-0' => ['Vendor_Namespace\\' => 'other-package/src'], 'psr-4' => ['Vendor\\Package\\' => 'other-package/Classes']]),
+            'package' => self::createPackage('fake/package', 'packages/fake_package', ['psr-0' => ['Vendor_Namespace\\' => 'src-psr0'], 'psr-4' => ['Vendor\\Package\\' => 'src-psr4']]),
+            'expectedDevAutoload' => [
+                'psr-0' => [
+                    'Vendor_Namespace\\' => [
+                        'other-package/src',
+                        'packages/fake_package/src-psr0',
+                    ],
+                ],
+                'psr-4' => [
+                    'Vendor\\Package\\' => [
+                        'other-package/Classes',
+                        'packages/fake_package/src-psr4',
+                    ],
+                ],
+            ],
+        ];
+        yield 'files namespaces are adopted' => [
+            'rootPackage' => self::createRootPackage('project/root'),
+            'package' => self::createPackage(
+                'fake/package',
+                'packages/fake_package',
+                [
+                    'files' => [
+                        'some/path/',
+                        'other/single.php',
+                    ],
+                ]
+            ),
+            'expectedDevAutoload' => [
+                'files' => [
+                    'packages/fake_package/some/path',
+                    'packages/fake_package/other/single.php',
+                ],
+            ],
+        ];
+        yield 'classmap namespaces are adopted' => [
+            'rootPackage' => self::createRootPackage('project/root'),
+            'package' => self::createPackage(
+                'fake/package',
+                'packages/fake_package',
+                [
+                    'classmap' => [
+                        'some/path/',
+                        'other/single.php',
+                    ],
+                ]
+            ),
+            'expectedDevAutoload' => [
+                'classmap' => [
+                    'packages/fake_package/some/path',
+                    'packages/fake_package/other/single.php',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider mergeAllNamespacesDataSets
+     * @test
+     */
+    public function mergeAllNamespacesModifiesRootPackageAsExpected(
+        RootPackageInterface $rootPackage,
+        BasePackage $package,
+        array $expectedDevAutoload
+    ): void {
+        $io = new NullIO();
+        $invoker = $this->createClassMethodInvoker(AutoloadMerger::class, 'mergeAllNamespaces');
+        $invoker->invoke(new AutoloadMerger(), $io, $rootPackage, $package);
+        self::assertSame($expectedDevAutoload, $rootPackage->getDevAutoload());
+    }
+}

--- a/tmpl/FixturePackages.php
+++ b/tmpl/FixturePackages.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace SBUERK;
+
+/**
+ * This file will be copied to `<vendor-dir>/sbuerk/FixturePackages.php`.
+ */
+final class FixturePackages
+{
+    private const DATA_FILE = 'fixture-packages.php';
+    private const TESTING_FRAMEWORK_COMPOSER_PACKAGE_MANAGER_CLASS_NAME = 'TYPO3\\TestingFramework\\Composer\\ComposerPackageManager';
+
+    /**
+     * @var array<string, array{name: string, type: string, path: string, extra: array<mixed>}>|null
+     */
+    private ?array $packages = null;
+
+    /**
+     * Adopt fixture TYPO3 extension to `typo3/testing-framework` ComposerPackageManager to allow using the composer
+     * package name or extension key for functional tests as `$coreExtensionToLoad` or `$extensionToLoad`.
+     *
+     * Throws \RuntimeException when `typo3/testing-framework` is not installed or incompatible.
+     */
+    public function adoptFixtureExtensions(): void
+    {
+        $className = self::TESTING_FRAMEWORK_COMPOSER_PACKAGE_MANAGER_CLASS_NAME;
+        if (!class_exists($className)) {
+            throw new \RuntimeException(
+                sprintf(
+                    'Adopting TYPO3 test fixture extensions not possible, "typo3/testing-framework" not'
+                    . ' installed or invalid version. Class missing: %s',
+                    self::TESTING_FRAMEWORK_COMPOSER_PACKAGE_MANAGER_CLASS_NAME
+                ),
+                1739708574
+            );
+        }
+        $packageNamesAndPaths = $this->packageNamesAndPaths(['typo3-cms-framework', 'typo3-cms-extension']);
+        $composerPackageManager = new $className();
+        if (method_exists($composerPackageManager, 'addFromPath')) {
+            foreach ($packageNamesAndPaths as $packagePath) {
+                // PHPStan mumbles also we have checked that already before foreach(), ignore only specific error here.
+                /** @phpstan-ignore method.nonObject */
+                $composerPackageManager->addFromPath($packagePath);
+            }
+            return;
+        }
+        foreach ($packageNamesAndPaths as $packageName => $packagePath) {
+            $packageInfo = $composerPackageManager->getPackageInfoWithFallback($packagePath);
+            if ($packageInfo === null) {
+                throw new \RuntimeException(
+                    sprintf(
+                        'Failed to load package info for "%s" in "%s".',
+                        $packageName,
+                        $packagePath
+                    ),
+                    1739709225
+                );
+            }
+            if (!($packageInfo->isSystemExtension() || $packageInfo->isExtension())) {
+                throw new \RuntimeException(
+                    sprintf(
+                        'Invalid package type for "%s" in "%s", must be "typo3-cms-framework" or "typo3-cms-extension", provided: "%s"',
+                        $packageName,
+                        $packagePath,
+                        $packageInfo->getType(),
+                    ),
+                    1739709734
+                );
+            }
+        }
+    }
+
+    /**
+     * @param string[]|null $filterComposerTypes
+     * @return array<string, array{name: string, type: string, path: string, extra: array<mixed>}>
+     */
+    public function packages(?array $filterComposerTypes = null): array
+    {
+        $this->packages ??= $this->loadPackages();
+        $packages = $this->packages;
+        if (!empty($filterComposerTypes)) {
+            $packages = array_filter(
+                $packages,
+                /**
+                 * @param array{name: string, type: string, path: string, extra: array<mixed>} $item
+                 */
+                static fn(array $item): bool => !in_array($item['type'], $filterComposerTypes, true)
+            );
+        }
+        return $packages;
+    }
+
+    /**
+     * @param string[]|null $filterComposerTypes
+     * @return string[]
+     */
+    public function packageNames(?array $filterComposerTypes = null): array
+    {
+        return array_keys($this->packages($filterComposerTypes));
+    }
+
+    /**
+     * @param string[]|null $filterComposerTypes
+     * @return array<string, string>
+     */
+    public function packageNamesAndPaths(?array $filterComposerTypes = null): array
+    {
+        $packages = $this->packages($filterComposerTypes);
+        return array_map('strval', array_column($packages, 'path', 'name'));
+    }
+
+    /**
+     * @return array<string, array{name: string, type: string, path: string, extra: array<mixed>}>
+     */
+    private function loadPackages(): array
+    {
+        return file_exists(__DIR__ . '/' . self::DATA_FILE)
+            ? include __DIR__ . '/' . self::DATA_FILE
+            : [];
+    }
+}


### PR DESCRIPTION
This pull-request implements the main feature this whole
package is about, including:

* Introduce root `composer.json` configuration to allow
  configuraiton paths to scan for packages.
* Adopt package composer.json `autoload` as root package
  `autoload-dev` on-the-fly during autoload dump action.
* Create a PHP file returning a simple array with found
  fixture packages and the paths.
* Create a `FixturePackages` class to work with the raw
  array information.
* Add an easy way to adopt for `typo3/testing-framework`
  based functional tests to make it possible to use the
  `composer package name` or `extension key` of fixture
  extensions instead of having to write relative file
  paths as `$testExtensionToLoad`.
* Extend `README.md` for basic installation, usage,
  configuration and further use like TYPO3 functional
  tests.

> [!NOTE]
> This pull-request already adds a lot of tests for the
> essential parts and make use of battle-tested composer
> utils instead of reimplementing own stuff, mainly for
> filesystem related operations.


- **[TASK] Enable php-cs-fixer for `tests/` folder**
  The `tests/` folder will also contain PHP code
  which **must** following the project cgl. It's
  now ensured by adding the folder to the config.
  

- **[TASK] Introduce unit testing based on `PHPUnit`**
  To provide the ability for testing code directly
  when adding it, unit testing infrastructure is
  added based on `PHPUnit`, integrated into the
  `Build/Scripts/runTests.sh` dispatcher and also
  enabled as GitHub action workflow.
  
  ```shell
  composer require --dev \
      "phpunit/phpunit":"9.6.22" \
      "phpstan/phpstan-phpunit":"^2.0.4"
  ```
  
  Resolves: #4
  Releases: main
  

- **[TASK] Add plugin configuration handling**
  This change introduces a dedicated config class
  holding the parsed extra section configuration,
  guarded with corresponding tests.
  

- **[FEATURE] Adopt test-fixture autoload as root autoload-dev**
  This change scans for TYPO3 test fixture extensions in
  configured paths and adopt configured non-dev autoload
  namepspaces as autoload-dev namespaces for the project
  root packge.
  
  Basic composer plugin handling is added along the way,
  and also additional phpstan packages added to enhance
  static code analyses in a reasonable way.
  
  Used command(s):
  
  ```shell
  composer require --dev \
    "phpstan/phpstan-symfony":"^2.0.2" \
    "phpstan/phpstan-deprecation-rules":"^2.0.1" \
    "phpstan/phpstan-phpunit":"^2.0.4"
  ```
  
  Resolves: #6
  Relases: main
  