### PR TITLE
[BUGFIX] Rewrite namespace paths based on distUrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Composer plugin `sbuerk/fixture-packages`
 
+> [!IMPORTANT]
+> **EXPERIMENTAL** for now, behaviour and configuration can and will change at
+> any point in a breaking way until baseline implementation has been proven as
+> battle-proof and 1.x is released.
+
 Package `sbuerk/fixture-packages` provides a development context composer plugin,
 which allows to define paths to scan for composer packages and adopt `autoload`
 registrations from package as `autoload-dev` registration of the root package,

--- a/tests/Integration/Fixtures/Instances/integration/File/SomeClass.php
+++ b/tests/Integration/Fixtures/Instances/integration/File/SomeClass.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace SomeVendor;
+
+final class SomeClass
+{
+    public function test(): string
+    {
+        return __METHOD__;
+    }
+}

--- a/tests/Integration/Fixtures/Instances/integration/composer.json
+++ b/tests/Integration/Fixtures/Instances/integration/composer.json
@@ -28,7 +28,10 @@
   "autoload": {
     "psr-4": {
       "Vendor\\ProjectOne\\": "Classes/"
-    }
+    },
+    "files": [
+      "File/SomeClass.php"
+    ]
   },
   "extra": {
     "sbuerk/fixture-packages": {

--- a/tests/Unit/Plugin/Util/AutoloadMergerTest.php
+++ b/tests/Unit/Plugin/Util/AutoloadMergerTest.php
@@ -35,21 +35,21 @@ final class AutoloadMergerTest extends BaseUnitTestCase
      * Create pseudo package instance to be used in tests.
      *
      * @param string $name
-     * @param string $sourceUrl
+     * @param string $distUrl
      * @param array{"psr-0"?: array<string, array<string>|string>, "psr-4"?: array<string, array<string>|string>, classmap?: list<string>, files?: list<string>} $autoload
      * @param array{"psr-0"?: array<string, array<string>|string>, "psr-4"?: array<string, array<string>|string>, classmap?: list<string>, files?: list<string>} $devAutoload
      * @return BasePackage
      */
     private static function createPackage(
         string $name,
-        string $sourceUrl,
+        string $distUrl,
         array $autoload = [],
         array $devAutoload = []
     ): BasePackage {
         $package = new Package($name, '1.0.0', '1.0.0.0');
         $package->setType('library');
-        $package->setSourceType('');
-        $package->setSourceUrl($sourceUrl);
+        $package->setDistType('');
+        $package->setDistUrl($distUrl);
         $package->setAutoload($autoload);
         $package->setDevAutoload($devAutoload);
         return $package;
@@ -103,8 +103,9 @@ final class AutoloadMergerTest extends BaseUnitTestCase
         string $namespacePath,
         string $expectedReturnValue
     ): void {
+        $io = new NullIO();
         $invoker = $this->createClassMethodInvoker(AutoloadMerger::class, 'modifyPackageNamespacePath');
-        self::assertSame($expectedReturnValue, $invoker->invoke(new AutoloadMerger(), $package, $namespacePath));
+        self::assertSame($expectedReturnValue, $invoker->invoke(new AutoloadMerger(), $io, $package, $namespacePath));
     }
 
     public static function mergePsrNamespaceDataSets(): \Generator


### PR DESCRIPTION
Usage in real live instances revealed broken
autoload information based on the fact that
the empty source url has been used instead
of the distUrl.

This change hardens the processing and used
now the correct value to determine package
paths. Tests based on wrong assumptions are
fixed along the way.
