### PR TITLE
[TASK] Use more suiting name for packages class

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,10 @@ schema to the extra-section and is used to configure paths to scan for extension
 
 This plugin create two files:
 
-| File                               | Description                                                                |
-|------------------------------------|----------------------------------------------------------------------------|
-| vendor/sbuerk/fixture-packages.php | Returns an array with fixture package information.                         |
-| vendor/sbuerk/FixturePackages.php  | Provides `FixturePackages` to work with fixture package information state. |
+| File                                       | Description                                                                         |
+|--------------------------------------------|-------------------------------------------------------------------------------------|
+| vendor/sbuerk/fixture-packages.php         | Returns an array with fixture package information.                                  |
+| vendor/sbuerk/AvailableFixturePackages.php | Provides `AvailableFixturePackages` to work with fixture package information state. |
 
 > [!NOTE]
 > These files are not generated to be used casually, but provides
@@ -121,8 +121,8 @@ This is not done automatically yet, but can be done easily by copy & paste
  * allow composer package name or extension keys of fixture extension in
  * {@see \TYPO3\TestingFramework\Core\Functional\FunctionalTestCase::$testExtensionToLoad}.
  */
-if (class_exists(\SBUERK\FixturePackages::class)) {
-    (new \SBUERK\FixturePackages())->adoptFixtureExtensions();
+if (class_exists(\SBUERK\AvailableFixturePackages::class)) {
+    (new \SBUERK\AvailableFixturePackages())->adoptFixtureExtensions();
 }
 ```
 
@@ -169,8 +169,8 @@ Usually, the bootstrap file for functional tests looks similar to the following:
      * allow composer package name or extension keys of fixture extension in
      * {@see \TYPO3\TestingFramework\Core\Functional\FunctionalTestCase::$testExtensionToLoad}.
      */
-    if (class_exists(\SBUERK\FixturePackages::class)) {
-        (new \SBUERK\FixturePackages())->adoptFixtureExtensions();
+    if (class_exists(\SBUERK\AvailableFixturePackages::class)) {
+        (new \SBUERK\AvailableFixturePackages())->adoptFixtureExtensions();
     }
 
     $testbase = new \TYPO3\TestingFramework\Core\Testbase();

--- a/src/Plugin/FixturePackagesService.php
+++ b/src/Plugin/FixturePackagesService.php
@@ -161,16 +161,27 @@ final class FixturePackagesService
             $fixturePackagesFile,
             '<?php return ' . $this->dumpToPhpCode($data) . ';' . "\n"
         );
-        if (file_exists($dataPath . '/FixturePackages.php')) {
-            $filesystem->unlink($dataPath . '/FixturePackages.php');
+        if (!file_exists(__DIR__ . '/../../tmpl/AvailableFixturePackages.php')) {
+            $io->writeError('>> [sbuerk/fixture-packages] Could not find AvailableFixturePackages class template.');
+            return;
         }
-        $filesystem->copy(__DIR__ . '/../../tmpl/FixturePackages.php', $dataPath . '/FixturePackages.php');
+        if (file_exists($dataPath . '/AvailableFixturePackages.php')
+            && hash_file('sha256', $dataPath . '/AvailableFixturePackages.php') !== hash_file('sha256', __DIR__ . '/../../tmpl/AvailableFixturePackages.php')
+        ) {
+            $filesystem->unlink($dataPath . '/AvailableFixturePackages');
+            $io->info('>> [sbuerk/fixture-packages] AvailableFixturePackages.php exists, but content changed. Remove it.');
+        }
+        if (!file_exists($dataPath . '/AvailableFixturePackages.php')) {
+            $io->info('>> [sbuerk/fixture-packages] Provide AvailableFixturePackages.php ');
+            $filesystem->copy(__DIR__ . '/../../tmpl/AvailableFixturePackages.php', $dataPath . '/AvailableFixturePackages.php');
+        }
         $rootPackage = $composer->getPackage();
         $devAutoload = $rootPackage->getDevAutoload();
         if (!isset($devAutoload['classmap']) || !is_array($devAutoload['classmap'])) {
             $devAutoload['classmap'] = [];
         }
-        $classFile = $composer->getConfig()->get('vendor-dir', \Composer\Config::RELATIVE_PATHS) . '/sbuerk/FixturePackages.php';
+        // Add AvailableFixturePackages class to root package autoload-dev
+        $classFile = $composer->getConfig()->get('vendor-dir', \Composer\Config::RELATIVE_PATHS) . '/sbuerk/AvailableFixturePackages.php';
         $devAutoload['classmap'][] = $classFile;
         $rootPackage->setDevAutoload($devAutoload);
     }

--- a/tmpl/AvailableFixturePackages.php
+++ b/tmpl/AvailableFixturePackages.php
@@ -18,9 +18,9 @@ declare(strict_types=1);
 namespace SBUERK;
 
 /**
- * This file will be copied to `<vendor-dir>/sbuerk/FixturePackages.php`.
+ * This file will be copied to `<vendor-dir>/sbuerk/AvailableFixturePackages.php`.
  */
-final class FixturePackages
+final class AvailableFixturePackages
 {
     private string $dataFile = __DIR__ . 'fixture-packages.php';
     private string $composerPackageManagerClassName = 'TYPO3\\TestingFramework\\Composer\\ComposerPackageManager';


### PR DESCRIPTION
This change renames the fixture packages handling
class from `FixturePackages.php` to more pleasant
`AvailableFixturePackages.php`.
