### PR TITLE
[BUGFIX] Add missing path separator in `AvailableFixturePackages`

### DIFF
--- a/tmpl/AvailableFixturePackages.php
+++ b/tmpl/AvailableFixturePackages.php
@@ -22,7 +22,7 @@ namespace SBUERK;
  */
 final class AvailableFixturePackages
 {
-    private string $dataFile = __DIR__ . 'fixture-packages.php';
+    private string $dataFile = __DIR__ . '/fixture-packages.php';
     private string $composerPackageManagerClassName = 'TYPO3\\TestingFramework\\Composer\\ComposerPackageManager';
 
     /**


### PR DESCRIPTION
The hardcoded path for the fixture packages json file
missed a path separator and effectly leading to empty
packages when used to register them for example with
the `typo3/testing-framework`.
