### PR TITLE
[FEATURE] Allow to select which autoload section to adopt

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ tests based on [PHPUnit](https://github.com/sebastianbergmann/phpunit).
 - [Generated files](#generated-files)
   - [Use generated `FixturePackages`](#use-generated-fixturepackages)
     - [[TYPO3] Functional testing with typo3/testing-framework](#typo3-functional-testing-with-typo3testing-framework)
+- [FAQ - Frequent Asked Questions](#faq---frequent-asked-questions)
 
 ## Installation
 
@@ -72,14 +73,67 @@ schema to the extra-section and is used to configure paths to scan for extension
 ```json
 {
   "extra": {
-    "sbuerk/fixture-packages": [
-      "multiple-packages-in-folder/*",
-      "pattern-matching/*/matching/same/subpath-in-multiple-places/*",
-      "packages/direct-package-path-containing-a-composer.json"
-    ]
+    "sbuerk/fixture-packages": {
+      "paths": {
+        "multiple-packages-in-folder/*": [
+          "autoload"
+        ],
+        "pattern-matching/*/matching/same/subpath-in-multiple-places/*": [
+          "autoload",
+          "autoload-dev"
+        ],
+        "packages/direct-package-path-containing-a-composer.json": [
+          "autoload-dev"
+        ]
+      }
+    }
   }
 }
 ```
+
+If adopting only `autoload` for all path configuration, simplified form **may** be used:
+
+```json
+{
+  "extra": {
+    "sbuerk/fixture-packages": {
+      "paths": [
+        "multiple-packages-in-folder/*",
+        "pattern-matching/*/matching/same/subpath-in-multiple-places/*",
+        "packages/direct-package-path-containing-a-composer.json"
+      ]
+    }
+  }
+}
+```
+
+which matches following **recommended** syntax, albeit beeing more to write but more expressive:
+
+```json
+{
+  "extra": {
+    "sbuerk/fixture-packages": {
+      "paths": {
+        "multiple-packages-in-folder/*": [
+          "autoload"
+        ],
+        "pattern-matching/*/matching/same/subpath-in-multiple-places/*": [
+          "autoload"
+        ],
+        "packages/direct-package-path-containing-a-composer.json": [
+          "autoload"
+        ]
+      }
+    }
+  }
+}
+```
+
+> [!NOTE]
+> It is possible to mix them, but requires to use integer indexes,
+> leading to a more brain-melting syntax and should be avoided, as
+> the support is only a co-existence and not technically disallowed
+> for now.
 
 ## Generated files
 
@@ -219,3 +273,15 @@ instead of something like
         'vendor/root-package',
     ];
 ```
+
+## FAQ - Frequent Asked Questions
+
+**Q: Will it be possible to add packages autoload to root package autoload in the future?**
+
+No. This package is a pure helper during development and there is no need for the provided
+namespace adoption in productions. Adopting non fully required packages namespaces or the
+`autoload-dev` namespaces from packages in production (`--no-dev` mode) leads to unforeseeable
+side effects. When this is needed, move your class to the autoload namespace or ask package
+maintainers to do so.
+
+This is also the reason why this plugin only operates in `--dev` mode.

--- a/src/Composer/Repository/FixturePathRepository.php
+++ b/src/Composer/Repository/FixturePathRepository.php
@@ -62,6 +62,11 @@ final class FixturePathRepository extends ArrayRepository implements Configurabl
     private $options;
 
     /**
+     * @var string[]
+     */
+    private array $adoptAutoloadSelection = [];
+
+    /**
      * Initializes path repository.
      *
      * @param array{url?: string, options?: array{symlink?: bool, reference?: string, relative?: bool, versions?: array<string, string>}} $repoConfig
@@ -71,7 +76,7 @@ final class FixturePathRepository extends ArrayRepository implements Configurabl
         if (!isset($repoConfig['url'])) {
             throw new \RuntimeException('You must specify the `url` configuration for the path repository');
         }
-
+        $this->adoptAutoloadSelection = (isset($repoConfig['selection']) && is_array($repoConfig['selection']) ? $repoConfig['selection'] : []);
         $this->loader = new ArrayLoader(null, true);
         $this->url = Platform::expandPath($repoConfig['url']);
         $this->process = $process ?? new ProcessExecutor($io);
@@ -94,6 +99,24 @@ final class FixturePathRepository extends ArrayRepository implements Configurabl
     public function getRepoConfig(): array
     {
         return $this->repoConfig;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getAdoptAutoloadSelection(): array
+    {
+        return $this->adoptAutoloadSelection;
+    }
+
+    public function adoptAutoload(): bool
+    {
+        return in_array('autoload', $this->adoptAutoloadSelection, true);
+    }
+
+    public function adoptAutoloadDev(): bool
+    {
+        return in_array('autoload-dev', $this->adoptAutoloadSelection, true);
     }
 
     /**

--- a/tests/Unit/Plugin/ConfigTest.php
+++ b/tests/Unit/Plugin/ConfigTest.php
@@ -191,7 +191,7 @@ final class ConfigTest extends BaseUnitTestCase
                 '/absolute/path'
             ),
         ];
-        yield 'non-relative fixture exetension paths are discarded and outputs warning, but keeps relative paths' => [
+        yield 'non-relative fixture extension paths are discarded and outputs warning, but keeps relative paths' => [
             'extraConfig' => [
                 'sbuerk/fixture-packages' => [
                     'paths' => [
@@ -203,7 +203,9 @@ final class ConfigTest extends BaseUnitTestCase
             'expectedConfigArray' => [
                 'sbuerk/fixture-packages' => [
                     'paths' => [
-                        'relative/path',
+                        'relative/path' => [
+                            'autoload',
+                        ],
                     ],
                 ],
             ],
@@ -305,7 +307,9 @@ final class ConfigTest extends BaseUnitTestCase
                 ],
             ],
             'expectedPaths' => [
-                'relative/path',
+                'relative/path' => [
+                    'autoload',
+                ],
             ],
             'expectedOutput' => sprintf(
                 '<warning>Test fixture extension path must be a subdirectory of Composer root directory. Skip "%s".</warning>' . PHP_EOL,

--- a/tests/Unit/Plugin/FixturePackagesServiceTest.php
+++ b/tests/Unit/Plugin/FixturePackagesServiceTest.php
@@ -74,7 +74,7 @@ final class FixturePackagesServiceTest extends BaseUnitTestCase
             'extra' => [
                 'sbuerk/fixture-packages' => [
                     'paths' => [
-                        'Fixtures/Extensions/*',
+                        'Fixtures/Extensions/*' => ['autoload'],
                     ],
                 ],
             ],
@@ -89,7 +89,7 @@ final class FixturePackagesServiceTest extends BaseUnitTestCase
             'extra' => [
                 'sbuerk/fixture-packages' => [
                     'paths' => [
-                        'Fixtures/*/*',
+                        'Fixtures/*/*' => ['autoload'],
                     ],
                 ],
             ],
@@ -107,7 +107,7 @@ final class FixturePackagesServiceTest extends BaseUnitTestCase
             'extra' => [
                 'sbuerk/fixture-packages' => [
                     'paths' => [
-                        'Packages/*/Fixtures/Extensions/*',
+                        'Packages/*/Fixtures/Extensions/*' => ['autoload'],
                     ],
                 ],
             ],
@@ -122,7 +122,7 @@ final class FixturePackagesServiceTest extends BaseUnitTestCase
             'extra' => [
                 'sbuerk/fixture-packages' => [
                     'paths' => [
-                        'Fixtures/Extensions/extension-one',
+                        'Fixtures/Extensions/extension-one' => ['autoload'],
                     ],
                 ],
             ],
@@ -160,7 +160,7 @@ final class FixturePackagesServiceTest extends BaseUnitTestCase
         $invokableCreateRepositoryManager = $this->createClassMethodInvoker($subject, 'createRepositoryManager');
         $invokableCreateRepositoryForPath = $this->createClassMethodInvoker($subject, 'createRepositoryForPath');
         $repositoryManager = $invokableCreateRepositoryManager->invoke($subject, $bufferedIo, $composer);
-        $repository = $invokableCreateRepositoryForPath->invoke($subject, $repositoryManager, $composer, $bufferedIo, $path);
+        $repository = $invokableCreateRepositoryForPath->invoke($subject, $repositoryManager, $composer, $bufferedIo, $path, ['autoload']);
         self::assertInstanceOf(RepositoryInterface::class, $repository);
         self::assertInstanceOf(FixturePathRepository::class, $repository);
         self::assertSame($expectedPackageNames, $this->getRepositoryPackageNames($repository));


### PR DESCRIPTION
In the first iteration only paths could be registered in
the root `composer.json` extra section like:

```json
{
  "extra": {
    "sbuerk/fixture-packages": {
      "paths": [
        "path/pattern/*"
      ],
    }
  }
}
```

adopting only the `autoload` from found packages to the
root package `autoload-dev` section. However, there is
a need to allow adopting also the `autoload-dev` either
together or only alone, mainly within mono repository
like setups to allow adopting test namespaces for normal
required packages from a local path repository folder.

The example above could also be written as:

```json
{
  "extra": {
    "sbuerk/fixture-packages": {
      "paths": {
        "path/pattern/*": [
          "autoload"
        ]
      },
    }
  }
}
```

To adopt `autoload` and `autoload-dev` from packages in
that path `autoload-dev` needs to be added to the array,
for example:

```json
{
  "extra": {
    "sbuerk/fixture-packages": {
      "paths": {
        "path/pattern/*": [
          "autoload",
          "autoload-dev",
        ]
      },
    }
  }
}
```

The simple path method is kept and is also combinable,
albeit needing to add at lest numbering indexes, based
on `json` schema constraints being otherwise invalid:

```json
{
  "extra": {
    "sbuerk/fixture-packages": {
      "paths": {
        "0": "simple/pattern/only/adopt/autoload/*",
        "path/pattern/*": [
          "autoload",
          "autoload-dev",
        ]
      },
    }
  }
}
```

Despite being possible, it's recommended to either use
only the simple format or the `key => array` pattern
for all entries due to human brain, easier readability
and reducing sources of errors.

Technically, the simple path notation is internally
transformed to `"path" => ["autoload"]"` keeping the
same behaviour as the initial feature introduction.

Tests expecting concrete outcome has been aligned to
match the enhanced selection mode and enriched with
additional tests to cover more matrix constellation
in different levels of the implementation.

To complete the task, documentation in `README.md`
is modified to reflect the introduced new feature
and states the handling, at least in a short way.
