### PR TITLE
[BUGFIX] Use correct filename to remove class file

### DIFF
--- a/src/Plugin/FixturePackagesService.php
+++ b/src/Plugin/FixturePackagesService.php
@@ -172,7 +172,7 @@ final class FixturePackagesService
         if (file_exists($dataPath . '/AvailableFixturePackages.php')
             && hash_file('sha256', $dataPath . '/AvailableFixturePackages.php') !== hash_file('sha256', __DIR__ . '/../../tmpl/AvailableFixturePackages.php')
         ) {
-            $filesystem->unlink($dataPath . '/AvailableFixturePackages');
+            $filesystem->unlink($dataPath . '/AvailableFixturePackages.php');
             $io->info('>> [sbuerk/fixture-packages] AvailableFixturePackages.php exists, but content changed. Remove it.');
         }
         if (!file_exists($dataPath . '/AvailableFixturePackages.php')) {


### PR DESCRIPTION
This composer plugins writes a json file and additionally
a dynamically generated class based on a template file,
and needs to remove it before writing it again. Detection
was correct, but the filename passed to unlink the existing
file missed the file extension. This is now corrected.
