### PR TITLE
[TASK] Allow fixture paths outside current project

### DIFF
--- a/src/Plugin/Config.php
+++ b/src/Plugin/Config.php
@@ -244,15 +244,6 @@ final class Config
                 }
             });
             $selection = array_filter($selection, fn($value) => in_array($value, ['autoload', 'autoload-dev']));
-            $normalizedPath = $config->normalizePath($path);
-            $realPath = $config->normalizePath($config->realpath($normalizedPath));
-            if (!str_starts_with($realPath, $basePath . '/')) {
-                $io->writeError(sprintf(
-                    '<warning>Test fixture extension path must be a subdirectory of Composer root directory. Skip "%s".</warning>',
-                    $path
-                ));
-                continue;
-            }
             if ($selection === []) {
                 $io->write(sprintf(
                     '<notice>No adopt mode selected for "%s" which means that none will be adopted, but package still taken as fixture package.".</notice>',

--- a/src/Plugin/FixturePackagesService.php
+++ b/src/Plugin/FixturePackagesService.php
@@ -43,7 +43,7 @@ final class FixturePackagesService
             // Only adopt namespace in development mode.
             return;
         }
-        /** @varr PackageInterface[] $adoptedPackages */
+        /** @var PackageInterface[] $adoptedPackages */
         $adoptedPackages = [];
         $config = Config::load($composer, $io);
         $autoloadMerger = new AutoloadMerger();

--- a/tests/Unit/Plugin/ConfigTest.php
+++ b/tests/Unit/Plugin/ConfigTest.php
@@ -173,65 +173,6 @@ final class ConfigTest extends BaseUnitTestCase
             ],
             'expectedOutput' => '<warning>extra->sbuerk/fixture-packages/paths must be an array, "boolean" given.</warning>' . PHP_EOL,
         ];
-        yield 'non-relative fixture extension paths are discarded and outputs warning' => [
-            'extraConfig' => [
-                'sbuerk/fixture-packages' => [
-                    'paths' => [
-                        '/absolute/path',
-                    ],
-                ],
-            ],
-            'expectedConfigArray' => [
-                'sbuerk/fixture-packages' => [
-                    'paths' => [],
-                ],
-            ],
-            'expectedOutput' => sprintf(
-                '<warning>Test fixture extension path must be a subdirectory of Composer root directory. Skip "%s".</warning>' . PHP_EOL,
-                '/absolute/path'
-            ),
-        ];
-        yield 'non-relative fixture extension paths are discarded and outputs warning, but keeps relative paths' => [
-            'extraConfig' => [
-                'sbuerk/fixture-packages' => [
-                    'paths' => [
-                        '/absolute/path',
-                        'relative/path',
-                    ],
-                ],
-            ],
-            'expectedConfigArray' => [
-                'sbuerk/fixture-packages' => [
-                    'paths' => [
-                        'relative/path' => [
-                            'autoload',
-                        ],
-                    ],
-                ],
-            ],
-            'expectedOutput' => sprintf(
-                '<warning>Test fixture extension path must be a subdirectory of Composer root directory. Skip "%s".</warning>' . PHP_EOL,
-                '/absolute/path'
-            ),
-        ];
-        yield 'relative path leaving composer root is discarded and outputs warning' => [
-            'extraConfig' => [
-                'sbuerk/fixture-packages' => [
-                    'paths' => [
-                        'relative/../../path-outside-composer-root',
-                    ],
-                ],
-            ],
-            'expectedConfigArray' => [
-                'sbuerk/fixture-packages' => [
-                    'paths' => [],
-                ],
-            ],
-            'expectedOutput' => sprintf(
-                '<warning>Test fixture extension path must be a subdirectory of Composer root directory. Skip "%s".</warning>' . PHP_EOL,
-                'relative/../../path-outside-composer-root'
-            ),
-        ];
     }
 
     /**
@@ -282,53 +223,6 @@ final class ConfigTest extends BaseUnitTestCase
             ],
             'expectedPaths' => [],
             'expectedOutput' => '<warning>extra->sbuerk/fixture-packages/paths must be an array, "boolean" given.</warning>' . PHP_EOL,
-        ];
-        yield 'non-relative fixture extension paths are discarded and outputs warning' => [
-            'extraConfig' => [
-                'sbuerk/fixture-packages' => [
-                    'paths' => [
-                        '/absolute/path',
-                    ],
-                ],
-            ],
-            'expectedPaths' => [],
-            'expectedOutput' => sprintf(
-                '<warning>Test fixture extension path must be a subdirectory of Composer root directory. Skip "%s".</warning>' . PHP_EOL,
-                '/absolute/path'
-            ),
-        ];
-        yield 'non-relative fixture exetension paths are discarded and outputs warning, but keeps relative paths' => [
-            'extraConfig' => [
-                'sbuerk/fixture-packages' => [
-                    'paths' => [
-                        '/absolute/path',
-                        'relative/path',
-                    ],
-                ],
-            ],
-            'expectedPaths' => [
-                'relative/path' => [
-                    'autoload',
-                ],
-            ],
-            'expectedOutput' => sprintf(
-                '<warning>Test fixture extension path must be a subdirectory of Composer root directory. Skip "%s".</warning>' . PHP_EOL,
-                '/absolute/path'
-            ),
-        ];
-        yield 'relative path leaving composer root is discarded and outputs warning' => [
-            'extraConfig' => [
-                'sbuerk/fixture-packages' => [
-                    'paths' => [
-                        'relative/../../path-outside-composer-root',
-                    ],
-                ],
-            ],
-            'expectedPaths' => [],
-            'expectedOutput' => sprintf(
-                '<warning>Test fixture extension path must be a subdirectory of Composer root directory. Skip "%s".</warning>' . PHP_EOL,
-                'relative/../../path-outside-composer-root'
-            ),
         ];
     }
 


### PR DESCRIPTION
Configure fixture package paths outside the root
composer.json path is a valid scenario, which is
currently prohibited.

This change removes the corresponding check and
allow this now, which allows advanced usage for
example in mono-repositories with dedicated test
paths using a central path from the outside.
